### PR TITLE
✨ feat(*): Stack Growth('pt-grow-stk-sc' Test FAIL) & Memory Mapped(WIP)

### DIFF
--- a/include/lib/kernel/hash.h
+++ b/include/lib/kernel/hash.h
@@ -39,19 +39,17 @@ struct hash_elem {
 	((STRUCT *) ((uint8_t *) &(HASH_ELEM)->list_elem        \
 		- offsetof (STRUCT, MEMBER.list_elem)))
 
-/* Computes and returns the hash value for hash element E, given
- * auxiliary data AUX. */
+/* 보조 데이터 AUX가 주어졌을 때, 해시 요소 E의 해시 값을 계산하여 반환합니다. */
 typedef uint64_t hash_hash_func (const struct hash_elem *e, void *aux);
 
-/* Compares the value of two hash elements A and B, given
- * auxiliary data AUX.  Returns true if A is less than B, or
- * false if A is greater than or equal to B. */
+/* 보조 데이터 AUX가 주어지면 두 해시 요소 A와 B의 값을 비교합니다.
+ * A가 B보다 작으면 true를 반환하고,
+ * A가 B보다 크거나 같으면 false를 반환합니다. */
 typedef bool hash_less_func (const struct hash_elem *a,
 		const struct hash_elem *b,
 		void *aux);
 
-/* Performs some operation on hash element E, given auxiliary
- * data AUX. */
+/* 보조 데이터 AUX가 주어지면 해시 요소 E에 대해 일부 연산을 수행합니다. */
 typedef void hash_action_func (struct hash_elem *e, void *aux);
 
 /* Hash table. */
@@ -96,5 +94,7 @@ bool hash_empty (struct hash *);
 uint64_t hash_bytes (const void *, size_t);
 uint64_t hash_string (const char *);
 uint64_t hash_int (int);
+
+
 
 #endif /* lib/kernel/hash.h */

--- a/include/lib/kernel/hash.h
+++ b/include/lib/kernel/hash.h
@@ -1,24 +1,19 @@
 #ifndef __LIB_KERNEL_HASH_H
 #define __LIB_KERNEL_HASH_H
 
-/* Hash table.
+/* 해시 테이블:
  *
- * This data structure is thoroughly documented in the Tour of
- * Pintos for Project 3.
+ * 이 자료구조는 Pintos Project 3의 Tour of Pintos에서 자세히 설명되어 있습니다.
  *
- * This is a standard hash table with chaining.  To locate an
- * element in the table, we compute a hash function over the
- * element's data and use that as an index into an array of
- * doubly linked lists, then linearly search the list.
+ * 이 구조는 체이닝(chaining)을 사용하는 표준 해시 테이블입니다. 테이블에서 요소를 찾으려면,
+ * 요소의 데이터에 대해 해시 함수를 계산하고, 그 값을 이중 연결 리스트 배열의 인덱스로 사용한 뒤,
+ * 해당 리스트를 선형 탐색합니다.
  *
- * The chain lists do not use dynamic allocation.  Instead, each
- * structure that can potentially be in a hash must embed a
- * struct hash_elem member.  All of the hash functions operate on
- * these `struct hash_elem's.  The hash_entry macro allows
- * conversion from a struct hash_elem back to a structure object
- * that contains it.  This is the same technique used in the
- * linked list implementation.  Refer to lib/kernel/list.h for a
- * detailed explanation. */
+ * 체인 리스트는 동적 할당을 사용하지 않습니다. 대신, 해시에 들어갈 수 있는 각 구조체는
+ * 반드시 struct hash_elem 멤버를 포함해야 합니다. 모든 해시 함수는 이 struct hash_elem을
+ * 대상으로 동작합니다. hash_entry 매크로를 사용하면 struct hash_elem에서
+ * 이를 포함하는 구조체 객체로 다시 변환할 수 있습니다. 이 기법은 연결 리스트 구현에서도
+ * 사용됩니다. 자세한 설명은 lib/kernel/list.h를 참고하세요. */
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -136,7 +136,8 @@ struct thread {
 
 #ifdef VM
     struct supplemental_page_table spt; /* 가상 메모리 테이블 */
-    void *user_rsp;                     /* %rsp 정보 저장 */ /* 25.06.03 정진영 추가 */
+    void *stack_lower_bound;            /* 스택이 현재까지 성장한 최하단 경계 */
+    void *saved_user_rsp;               /* 유저 모드 %rsp 저장용 (page fault 시 사용) */
 #endif
 	struct semaphore wait_sema;
 	struct semaphore fork_sema;

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -136,7 +136,7 @@ struct thread {
 
 #ifdef VM
     struct supplemental_page_table spt; /* 가상 메모리 테이블 */
-    uint64_t user_rsp;                  /* rsp 담을 필드 */ /* 25.06.03 정진영 추가 */
+    void *user_rsp;                     /* %rsp 정보 저장 */ /* 25.06.03 정진영 추가 */
 #endif
 	struct semaphore wait_sema;
 	struct semaphore fork_sema;

--- a/include/threads/thread.h
+++ b/include/threads/thread.h
@@ -136,11 +136,11 @@ struct thread {
 
 #ifdef VM
     struct supplemental_page_table spt; /* 가상 메모리 테이블 */
+    uint64_t user_rsp;                  /* rsp 담을 필드 */ /* 25.06.03 정진영 추가 */
 #endif
 	struct semaphore wait_sema;
 	struct semaphore fork_sema;
 	struct semaphore exit_sema;
-
 
     /* Owned by thread.c. */
     struct intr_frame tf;               /* 스위칭 정보 */

--- a/include/userprog/process.h
+++ b/include/userprog/process.h
@@ -21,4 +21,8 @@ int process_add_file(struct file *f);
 struct file *process_get_file(int fd);
 int process_close_file(int fd);
 
+#ifdef VM
+bool lazy_load_segment(struct page *page, void *aux);
+#endif
+
 #endif /* userprog/process.h */

--- a/include/vm/anon.h
+++ b/include/vm/anon.h
@@ -4,7 +4,11 @@
 struct page;
 enum vm_type;
 
-struct anon_page {
+struct anon_page 
+{
+     /* 25.05.30 정진영 작성
+     음수이면 스왑 아웃 상태가 아님 */
+     int swap_idx;
 };
 
 void vm_anon_init (void);

--- a/include/vm/file.h
+++ b/include/vm/file.h
@@ -2,11 +2,20 @@
 #define VM_FILE_H
 #include "filesys/file.h"
 #include "vm/vm.h"
+#include <stddef.h>
+#include <stdint.h>
 
 struct page;
 enum vm_type;
 
 struct file_page {
+};
+
+struct lazy_load_arg {
+	struct file *file;
+	off_t ofs;
+	uint32_t read_bytes;
+	uint32_t zero_bytes;
 };
 
 void vm_file_init (void);

--- a/include/vm/file.h
+++ b/include/vm/file.h
@@ -9,6 +9,10 @@ struct page;
 enum vm_type;
 
 struct file_page {
+	struct file *file;
+	off_t ofs;
+	uint32_t read_bytes;
+	uint32_t zero_bytes;
 };
 
 struct lazy_load_arg {

--- a/include/vm/file.h
+++ b/include/vm/file.h
@@ -15,12 +15,13 @@ struct file_page {
 	uint32_t zero_bytes;
 };
 
-struct lazy_load_arg {
-	struct file *file;
-	off_t ofs;
-	uint32_t read_bytes;
-	uint32_t zero_bytes;
-};
+// vm.h로 옮기자
+// struct lazy_load_arg {
+// 	struct file *file;
+// 	off_t ofs;
+// 	uint32_t read_bytes;
+// 	uint32_t zero_bytes;
+// };
 
 void vm_file_init (void);
 bool file_backed_initializer (struct page *page, enum vm_type type, void *kva);

--- a/include/vm/uninit.h
+++ b/include/vm/uninit.h
@@ -1,3 +1,8 @@
+/* uninit.h:
+ * 접근 시점까지 로딩을 지연하는 초기화되지 않은 페이지를 정의합니다.
+ * 가상 메모리 시스템에서 Lazy Loading을 지원하기 위해 사용됩니다.
+ */
+
 #ifndef VM_UNINIT_H
 #define VM_UNINIT_H
 #include "vm/vm.h"
@@ -12,7 +17,7 @@ typedef bool vm_initializer (struct page *, void *aux);
 struct uninit_page {
 	/* Initiate the contets of the page */
 	vm_initializer *init;
-	enum vm_type type;
+	enum vm_type type;			/* 페이지 폴트 시 초기화 될 페이지 타입 */
 	void *aux;
 	/* Initiate the struct page and maps the pa to the va */
 	bool (*page_initializer) (struct page *, enum vm_type, void *kva);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -1,26 +1,33 @@
+/* vm.h: 
+ * 가상 메모리(Virtual Memory) 시스템이 지원해야 하는 각기 다른 vm_type(가상 메모리 타입)들 
+ * -- VM_UNINIT, VM_ANON, VM_FILE, VM_PAGE_CACHE -- 의 정의와 설명
+ */
+
 #ifndef VM_VM_H
 #define VM_VM_H
 #include <stdbool.h>
 #include "threads/palloc.h"
 
 enum vm_type {
-	/* page not initialized */
+	/* 초기화되지 않은 페이지 */
 	VM_UNINIT = 0,
-	/* page not related to the file, aka anonymous page */
+	/* 파일과 관련 없는 페이지, 즉 익명 페이지 */
 	VM_ANON = 1,
-	/* page that realated to the file */
+	/* 파일과 관련된 페이지 */
 	VM_FILE = 2,
-	/* page that hold the page cache, for project 4 */
+	/* 페이지 캐시를 보유하는 페이지, for project 4 */
 	VM_PAGE_CACHE = 3,
+	/* mmap 파일 페이지 */
+	VM_MMAP = 4,
 
-	/* Bit flags to store state */
+	/* 상태를 저장하기 위한 비트 플래그 */
 
-	/* Auxillary bit flag marker for store information. You can add more
-	 * markers, until the value is fit in the int. */
+	/* 추가 정보를 저장하기 위한 보조 비트 플래그 마커입니다.
+	 * int 범위 내에서 값을 추가할 수 있습니다. */
 	VM_MARKER_0 = (1 << 3),
 	VM_MARKER_1 = (1 << 4),
 
-	/* DO NOT EXCEED THIS VALUE. */
+	/* 이 값을 초과하지 마세요. */
 	VM_MARKER_END = (1 << 31),
 };
 
@@ -36,19 +43,23 @@ struct thread;
 
 #define VM_TYPE(type) ((type) & 7)
 
-/* The representation of "page".
- * This is kind of "parent class", which has four "child class"es, which are
- * uninit_page, file_page, anon_page, and page cache (project4).
- * DO NOT REMOVE/MODIFY PREDEFINED MEMBER OF THIS STRUCTURE. */
+/* "페이지" 표현
+ * 이는 일종의 "부모 클래스"이며, 네 개의 "자식 클래스"를 갖습니다.
+ * uninit_page, file_page, anon_page, 그리고 page cache(project4)입니다.
+ * 이 구조체의 미리 정의된 멤버를 제거하거나 수정하지 마십시오. */
 struct page {
 	const struct page_operations *operations;
 	void *va;              /* Address in terms of user space */
 	struct frame *frame;   /* Back reference for frame */
 
 	/* Your implementation */
+	/* 25.05.30 고재웅 작성 */
+	struct hash_elem hash_elem;			// 해시 저장용 elem
+	bool writable; 						// 쓰기 가능한 페이지 인지
+	bool is_loaded;						// 실제로 프레임에 로드되어 있는지
 
-	/* Per-type data are binded into the union.
-	 * Each function automatically detects the current union */
+	/* 타입별 데이터는 union에 바인딩됩니다.
+	 * 각 함수는 현재 union을 자동으로 감지합니다. */
 	union {
 		struct uninit_page uninit;
 		struct anon_page anon;
@@ -65,10 +76,10 @@ struct frame {
 	struct page *page;
 };
 
-/* The function table for page operations.
- * This is one way of implementing "interface" in C.
- * Put the table of "method" into the struct's member, and
- * call it whenever you needed. */
+/* 페이지 작업을 위한 함수 테이블입니다.
+ * 이는 C에서 "인터페이스"를 구현하는 한 가지 방법입니다.
+ * "메서드"의 테이블을 구조체의 멤버에 넣고,
+ * 필요할 때마다 호출하면 됩니다. */
 struct page_operations {
 	bool (*swap_in) (struct page *, void *);
 	bool (*swap_out) (struct page *);
@@ -81,10 +92,12 @@ struct page_operations {
 #define destroy(page) \
 	if ((page)->operations->destroy) (page)->operations->destroy (page)
 
-/* Representation of current process's memory space.
- * We don't want to force you to obey any specific design for this struct.
- * All designs up to you for this. */
+/* 현재 프로세스의 메모리 공간을 나타냅니다.
+ * 이 구조체에 대해 특정 설계를 강제하지 않습니다.
+ * 모든 설계는 여러분에게 달려 있습니다. */
 struct supplemental_page_table {
+	/* 25.05.30 고재웅 작성 */
+	struct hash pages; 
 };
 
 #include "threads/thread.h"
@@ -108,5 +121,10 @@ bool vm_alloc_page_with_initializer (enum vm_type type, void *upage,
 void vm_dealloc_page (struct page *page);
 bool vm_claim_page (void *va);
 enum vm_type page_get_type (struct page *page);
+
+/* 25.05.30 고재웅 작성 */
+/* SPT 해시 테이블에 넣기 위한 hash_func & less_func 함수 선언 */
+uint64_t page_hash(const struct hash_elem *e, void *aux);
+bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux);
 
 #endif  /* VM_VM_H */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -1,3 +1,8 @@
+/* vm.h: 
+ * 가상 메모리(Virtual Memory) 시스템이 지원해야 하는 각기 다른 vm_type(가상 메모리 타입)들 
+ * -- VM_UNINIT, VM_ANON, VM_FILE, VM_PAGE_CACHE -- 의 정의와 설명
+ */
+
 #ifndef VM_VM_H
 #define VM_VM_H
 #include <stdbool.h>
@@ -5,23 +10,25 @@
 #include "threads/palloc.h"
 
 enum vm_type {
-	/* page not initialized */
+	/* 초기화되지 않은 페이지 */
 	VM_UNINIT = 0,
-	/* page not related to the file, aka anonymous page */
+	/* 파일과 관련 없는 페이지, 즉 익명 페이지 */
 	VM_ANON = 1,
-	/* page that realated to the file */
+	/* 파일과 관련된 페이지 */
 	VM_FILE = 2,
-	/* page that hold the page cache, for project 4 */
+	/* 페이지 캐시를 보유하는 페이지, for project 4 */
 	VM_PAGE_CACHE = 3,
+	/* mmap 파일 페이지 */
+	VM_MMAP = 4,
 
-	/* Bit flags to store state */
+	/* 상태를 저장하기 위한 비트 플래그 */
 
-	/* Auxillary bit flag marker for store information. You can add more
-	 * markers, until the value is fit in the int. */
+	/* 추가 정보를 저장하기 위한 보조 비트 플래그 마커입니다.
+	 * int 범위 내에서 값을 추가할 수 있습니다. */
 	VM_MARKER_0 = (1 << 3),
 	VM_MARKER_1 = (1 << 4),
 
-	/* DO NOT EXCEED THIS VALUE. */
+	/* 이 값을 초과하지 마세요. */
 	VM_MARKER_END = (1 << 31),
 };
 
@@ -38,7 +45,7 @@ struct list frame_table;
 
 #define VM_TYPE(type) ((type) & 7)
 
-/* "페이지" 표현.
+/* "페이지" 표현
  * 이는 일종의 "부모 클래스"이며, 네 개의 "자식 클래스"를 갖습니다.
  * uninit_page, file_page, anon_page, 그리고 page cache(project4)입니다.
  * 이 구조체의 미리 정의된 멤버를 제거하거나 수정하지 마십시오. */
@@ -53,8 +60,8 @@ struct page {
 	bool writable; 						// 쓰기 가능한 페이지 인지
 	bool is_loaded;						// 실제로 프레임에 로드되어 있는지
 
-	/* Per-type data are binded into the union.
-	 * Each function automatically detects the current union */
+	/* 타입별 데이터는 union에 바인딩됩니다.
+	 * 각 함수는 현재 union을 자동으로 감지합니다. */
 	union {
 		struct uninit_page uninit;
 		struct anon_page anon;
@@ -69,17 +76,16 @@ struct page {
 struct frame {
 	void *kva;
 	struct page *page;
-
 	struct list_elem elem; 
 	struct thread *owner;
 	bool pinned;
 
 };
 
-/* The function table for page operations.
- * This is one way of implementing "interface" in C.
- * Put the table of "method" into the struct's member, and
- * call it whenever you needed. */
+/* 페이지 작업을 위한 함수 테이블입니다.
+ * 이는 C에서 "인터페이스"를 구현하는 한 가지 방법입니다.
+ * "메서드"의 테이블을 구조체의 멤버에 넣고,
+ * 필요할 때마다 호출하면 됩니다. */
 struct page_operations {
 	bool (*swap_in) (struct page *, void *);
 	bool (*swap_out) (struct page *);
@@ -92,9 +98,9 @@ struct page_operations {
 #define destroy(page) \
 	if ((page)->operations->destroy) (page)->operations->destroy (page)
 
-/* Representation of current process's memory space.
- * We don't want to force you to obey any specific design for this struct.
- * All designs up to you for this. */
+/* 현재 프로세스의 메모리 공간을 나타냅니다.
+ * 이 구조체에 대해 특정 설계를 강제하지 않습니다.
+ * 모든 설계는 여러분에게 달려 있습니다. */
 struct supplemental_page_table {
 	/* 25.05.30 고재웅 작성 */
 	struct hash pages; 
@@ -126,6 +132,5 @@ enum vm_type page_get_type (struct page *page);
 /* SPT 해시 테이블에 넣기 위한 hash_func & less_func 함수 선언 */
 uint64_t page_hash(const struct hash_elem *e, void *aux);
 bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux);
-
 
 #endif  /* VM_VM_H */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -77,9 +77,6 @@ struct frame {
 	void *kva;
 	struct page *page;
 	struct list_elem elem; 
-	struct thread *owner;
-	bool pinned;
-
 };
 
 /* 페이지 작업을 위한 함수 테이블입니다.
@@ -132,5 +129,6 @@ enum vm_type page_get_type (struct page *page);
 /* SPT 해시 테이블에 넣기 위한 hash_func & less_func 함수 선언 */
 uint64_t page_hash(const struct hash_elem *e, void *aux);
 bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux);
+void hash_page_destroy(struct hash_elem *e, void *aux);
 
 #endif  /* VM_VM_H */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -6,6 +6,7 @@
 #ifndef VM_VM_H
 #define VM_VM_H
 #include <stdbool.h>
+#include <hash.h>
 #include "threads/palloc.h"
 
 enum vm_type {
@@ -40,6 +41,7 @@ enum vm_type {
 
 struct page_operations;
 struct thread;
+struct list frame_table;
 
 #define VM_TYPE(type) ((type) & 7)
 
@@ -74,6 +76,10 @@ struct page {
 struct frame {
 	void *kva;
 	struct page *page;
+	struct list_elem elem; 
+	struct thread *owner;
+	bool pinned;
+
 };
 
 /* 페이지 작업을 위한 함수 테이블입니다.

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -1,6 +1,7 @@
 #ifndef VM_VM_H
 #define VM_VM_H
 #include <stdbool.h>
+#include <hash.h>
 #include "threads/palloc.h"
 
 enum vm_type {
@@ -33,6 +34,7 @@ enum vm_type {
 
 struct page_operations;
 struct thread;
+struct list frame_table;
 
 #define VM_TYPE(type) ((type) & 7)
 
@@ -67,6 +69,11 @@ struct page {
 struct frame {
 	void *kva;
 	struct page *page;
+
+	struct list_elem elem; 
+	struct thread *owner;
+	bool pinned;
+
 };
 
 /* The function table for page operations.
@@ -117,7 +124,7 @@ enum vm_type page_get_type (struct page *page);
 
 /* 25.05.30 고재웅 작성 */
 /* SPT 해시 테이블에 넣기 위한 hash_func & less_func 함수 선언 */
-uint64_t page_hash(onst struct hash_elem *e, void *aux);
+uint64_t page_hash(const struct hash_elem *e, void *aux);
 bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux);
 
 

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -6,8 +6,8 @@
 #ifndef VM_VM_H
 #define VM_VM_H
 #include <stdbool.h>
-#include <hash.h>
 #include "threads/palloc.h"
+#include <hash.h>	/* Project 3: Memory Management */
 
 enum vm_type {
 	/* 초기화되지 않은 페이지 */
@@ -50,9 +50,9 @@ struct list frame_table;
  * uninit_page, file_page, anon_page, 그리고 page cache(project4)입니다.
  * 이 구조체의 미리 정의된 멤버를 제거하거나 수정하지 마십시오. */
 struct page {
-	const struct page_operations *operations;
-	void *va;              /* Address in terms of user space */
-	struct frame *frame;   /* Back reference for frame */
+	const struct page_operations *operations;	/* 페이지에 대한 동작 함수 (swap-in, swap-out 등) */
+	void *va;              						/* 사용자 주소 공간의 가상 주소 */
+	struct frame *frame;   						/* 이 페이지가 매핑된 물리 프레임 */
 
 	/* Your implementation */
 	/* 25.05.30 고재웅 작성 */
@@ -60,8 +60,8 @@ struct page {
 	bool writable; 						// 쓰기 가능한 페이지 인지
 	bool is_loaded;						// 실제로 프레임에 로드되어 있는지
 
-	/* 타입별 데이터는 union에 바인딩됩니다.
-	 * 각 함수는 현재 union을 자동으로 감지합니다. */
+	/* union은 여러 타입 중 하나만을 저장할 수 있는 특수한 자료형으로,  
+	 * 타입별 데이터는 union에 바인딩 됩니다. 각 함수는 현재 union을 자동으로 감지합니다. */
 	union {
 		struct uninit_page uninit;
 		struct anon_page anon;
@@ -103,7 +103,7 @@ struct page_operations {
  * 모든 설계는 여러분에게 달려 있습니다. */
 struct supplemental_page_table {
 	/* 25.05.30 고재웅 작성 */
-	struct hash pages; 
+	struct hash pages;
 };
 
 #include "threads/thread.h"

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -36,16 +36,20 @@ struct thread;
 
 #define VM_TYPE(type) ((type) & 7)
 
-/* The representation of "page".
- * This is kind of "parent class", which has four "child class"es, which are
- * uninit_page, file_page, anon_page, and page cache (project4).
- * DO NOT REMOVE/MODIFY PREDEFINED MEMBER OF THIS STRUCTURE. */
+/* "페이지" 표현.
+ * 이는 일종의 "부모 클래스"이며, 네 개의 "자식 클래스"를 갖습니다.
+ * uninit_page, file_page, anon_page, 그리고 page cache(project4)입니다.
+ * 이 구조체의 미리 정의된 멤버를 제거하거나 수정하지 마십시오. */
 struct page {
 	const struct page_operations *operations;
 	void *va;              /* Address in terms of user space */
 	struct frame *frame;   /* Back reference for frame */
 
 	/* Your implementation */
+	/* 25.05.30 고재웅 작성 */
+	struct hash_elem hash_elem;			// 해시 저장용 elem
+	bool writable; 						// 쓰기 가능한 페이지 인지
+	bool is_loaded;						// 실제로 프레임에 로드되어 있는지
 
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
@@ -85,6 +89,8 @@ struct page_operations {
  * We don't want to force you to obey any specific design for this struct.
  * All designs up to you for this. */
 struct supplemental_page_table {
+	/* 25.05.30 고재웅 작성 */
+	struct hash pages; 
 };
 
 #include "threads/thread.h"
@@ -108,5 +114,11 @@ bool vm_alloc_page_with_initializer (enum vm_type type, void *upage,
 void vm_dealloc_page (struct page *page);
 bool vm_claim_page (void *va);
 enum vm_type page_get_type (struct page *page);
+
+/* 25.05.30 고재웅 작성 */
+/* SPT 해시 테이블에 넣기 위한 hash_func & less_func 함수 선언 */
+uint64_t page_hash(onst struct hash_elem *e, void *aux);
+bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux);
+
 
 #endif  /* VM_VM_H */

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -45,6 +45,7 @@ struct list frame_table;
 
 #define VM_TYPE(type) ((type) & 7)
 
+/* 25.06.04 정진영 수정 (mmap_idx 추가) */
 /* "페이지" 표현
  * 이는 일종의 "부모 클래스"이며, 네 개의 "자식 클래스"를 갖습니다.
  * uninit_page, file_page, anon_page, 그리고 page cache(project4)입니다.
@@ -59,6 +60,7 @@ struct page {
 	struct hash_elem hash_elem;			// 해시 저장용 elem
 	bool writable; 						// 쓰기 가능한 페이지 인지
 	bool is_loaded;						// 실제로 프레임에 로드되어 있는지
+	int mmap_idx;						// mmap 전체 중 몇번째 페이지인지를 기록
 
 	/* union은 여러 타입 중 하나만을 저장할 수 있는 특수한 자료형으로,  
 	 * 타입별 데이터는 union에 바인딩 됩니다. 각 함수는 현재 union을 자동으로 감지합니다. */
@@ -76,7 +78,7 @@ struct page {
 struct frame {
 	void *kva;
 	struct page *page;
-	struct list_elem elem; 
+	struct list_elem elem;	/* 25.05.30 고재웅 작성 */
 };
 
 /* 페이지 작업을 위한 함수 테이블입니다.

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -92,6 +92,33 @@ struct page_operations {
 	enum vm_type type;
 };
 
+/* lazy load 시 사용되는 argument 구조체 */
+struct lazy_load_arg {
+    struct file *file;
+    off_t ofs;
+    uint32_t read_bytes;
+    uint32_t zero_bytes;
+};
+
+/* lazy load 시 사용되는 argument 구조체 */
+// struct lazy_load_arg {
+//     enum vm_type type;
+//     union {
+//         struct {
+//             struct file *file;
+//             off_t ofs;
+//             uint32_t read_bytes;
+//             uint32_t zero_bytes;
+//         } file_arg;
+//         struct {
+//             struct file *file;
+//             off_t ofs;
+//             uint32_t read_bytes;
+//             uint32_t zero_bytes;
+//         } anon_arg;
+//     };
+// };
+
 #define swap_in(page, v) (page)->operations->swap_in ((page), v)
 #define swap_out(page) (page)->operations->swap_out (page)
 #define destroy(page) \
@@ -101,8 +128,7 @@ struct page_operations {
  * 이 구조체에 대해 특정 설계를 강제하지 않습니다.
  * 모든 설계는 여러분에게 달려 있습니다. */
 struct supplemental_page_table {
-	/* 25.05.30 고재웅 작성 */
-	struct hash pages;
+	struct hash pages;		/* 25.05.30 고재웅 작성 */
 };
 
 #include "threads/thread.h"

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -133,4 +133,7 @@ uint64_t page_hash(const struct hash_elem *e, void *aux);
 bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux);
 void hash_page_destroy(struct hash_elem *e, void *aux);
 
+/* 25.06.06 정진영 작성 */
+#define STACK_LIMIT (USER_STACK - (1 << 20))
+
 #endif  /* VM_VM_H */

--- a/lib/kernel/hash.c
+++ b/lib/kernel/hash.c
@@ -275,7 +275,7 @@ uint64_t
 hash_int (int i) {
 	return hash_bytes (&i, sizeof i);
 }
-
+
 /* Returns the bucket in H that E belongs in. */
 static struct list *
 find_bucket (struct hash *h, struct hash_elem *e) {

--- a/tests/vm/pt-write-code.c
+++ b/tests/vm/pt-write-code.c
@@ -1,5 +1,7 @@
 /* Try to write to the code segment.
    The process must be terminated with -1 exit code. */
+   
+/* 코드 영역 (read-only)에 쓰기 접근 시, 이를 막아야 성공 */
 
 #include "tests/lib.h"
 #include "tests/main.h"

--- a/threads/mmu.c
+++ b/threads/mmu.c
@@ -55,12 +55,11 @@ pdpe_walk (uint64_t *pdpe, const uint64_t va, int create) {
 	return pte;
 }
 
-/* Returns the address of the page table entry for virtual
- * address VADDR in page map level 4, pml4.
- * If PML4E does not have a page table for VADDR, behavior depends
- * on CREATE.  If CREATE is true, then a new page table is
- * created and a pointer into it is returned.  Otherwise, a null
- * pointer is returned. */
+/* 페이지 맵 레벨 4(pml4)의 가상 주소 VADDR에 대한 페이지 테이블 항목의 주소를 반환합니다.
+ * PML4E에 VADDR에 대한 페이지 테이블이 없는 경우, 동작은
+ * CREATE에 따라 달라집니다. CREATE가 참이면 새 페이지 테이블이 생성되고
+ * 해당 페이지 테이블에 대한 포인터가 반환됩니다. 그렇지 않으면 null
+ * 포인터가 반환됩니다. */
 uint64_t *
 pml4e_walk (uint64_t *pml4e, const uint64_t va, int create) {
 	uint64_t *pte = NULL;
@@ -88,10 +87,8 @@ pml4e_walk (uint64_t *pml4e, const uint64_t va, int create) {
 	return pte;
 }
 
-/* Creates a new page map level 4 (pml4) has mappings for kernel
- * virtual addresses, but none for user virtual addresses.
- * Returns the new page directory, or a null pointer if memory
- * allocation fails. */
+/* 새로운 페이지 맵 레벨 4(pml4)를 생성합니다. 커널 가상 주소에 대한 매핑은 있지만, 사용자 가상 주소에 대한 매핑은 없습니다.
+ * 새 페이지 디렉터리를 반환하거나, 메모리 할당에 실패하면 널 포인터를 반환합니다. */
 uint64_t *
 pml4_create (void) {
 	uint64_t *pml4 = palloc_get_page (0);
@@ -199,17 +196,16 @@ pml4_destroy (uint64_t *pml4) {
 	palloc_free_page ((void *) pml4);
 }
 
-/* Loads page directory PD into the CPU's page directory base
- * register. */
+/* 페이지 디렉토리 PD를 CPU의 페이지 디렉토리 베이스
+ * 레지스터에 로드합니다. */
 void
 pml4_activate (uint64_t *pml4) {
 	lcr3 (vtop (pml4 ? pml4 : base_pml4));
 }
 
-/* Looks up the physical address that corresponds to user virtual
- * address UADDR in pml4.  Returns the kernel virtual address
- * corresponding to that physical address, or a null pointer if
- * UADDR is unmapped. */
+/* pml4에서 사용자 가상 주소 UADDR에 해당하는 물리 주소를 찾습니다.
+ * 해당 물리 주소에 해당하는 커널 가상 주소 또는
+ * UADDR이 매핑되지 않은 경우 널 포인터를 반환합니다. */
 void *
 pml4_get_page (uint64_t *pml4, const void *uaddr) {
 	ASSERT (is_user_vaddr (uaddr));
@@ -221,14 +217,13 @@ pml4_get_page (uint64_t *pml4, const void *uaddr) {
 	return NULL;
 }
 
-/* Adds a mapping in page map level 4 PML4 from user virtual page
- * UPAGE to the physical frame identified by kernel virtual address KPAGE.
- * UPAGE must not already be mapped. KPAGE should probably be a page obtained
- * from the user pool with palloc_get_page().
- * If WRITABLE is true, the new page is read/write;
- * otherwise it is read-only.
- * Returns true if successful, false if memory allocation
- * failed. */
+/* 사용자 가상 페이지에서 페이지 맵 레벨 4 PML4 매핑을 추가합니다.
+ * 커널 가상 주소 KPAGE로 식별되는 물리적 프레임에 UPAGE를 추가합니다.
+ * UPAGE는 이미 매핑되어서는 안 됩니다. KPAGE는 palloc_get_page()를 사용하여 사용자 풀에서 가져온 페이지여야 합니다.
+ * WRITABLE이 true이면 새 페이지는 읽기/쓰기가 가능합니다.
+ * 그렇지 않으면 읽기 전용입니다.
+ * 성공하면 true를 반환하고, 메모리 할당이 실패하면 false를 반환합니다.
+ * */
 bool
 pml4_set_page (uint64_t *pml4, void *upage, void *kpage, bool rw) {
 	ASSERT (pg_ofs (upage) == 0);
@@ -243,10 +238,10 @@ pml4_set_page (uint64_t *pml4, void *upage, void *kpage, bool rw) {
 	return pte != NULL;
 }
 
-/* Marks user virtual page UPAGE "not present" in page
- * directory PD.  Later accesses to the page will fault.  Other
- * bits in the page table entry are preserved.
- * UPAGE need not be mapped. */
+/* 사용자 가상 페이지 UPAGE를 페이지 디렉터리 PD에 "없음"으로 표시합니다.
+ * 이후 해당 페이지에 액세스하면 오류가 발생합니다.
+ * 페이지 테이블 항목의 다른 비트는 유지됩니다.
+ * UPAGE는 매핑할 필요가 없습니다. */
 void
 pml4_clear_page (uint64_t *pml4, void *upage) {
 	uint64_t *pte;
@@ -262,10 +257,9 @@ pml4_clear_page (uint64_t *pml4, void *upage) {
 	}
 }
 
-/* Returns true if the PTE for virtual page VPAGE in PML4 is dirty,
- * that is, if the page has been modified since the PTE was
- * installed.
- * Returns false if PML4 contains no PTE for VPAGE. */
+/* PML4의 가상 페이지 VPAGE에 대한 PTE가 변경된 경우, 즉
+ * PTE가 설치된 이후 페이지가 수정된 경우 true를 반환합니다.
+ * PML4에 VPAGE에 대한 PTE가 없는 경우 false를 반환합니다. */
 bool
 pml4_is_dirty (uint64_t *pml4, const void *vpage) {
 	uint64_t *pte = pml4e_walk (pml4, (uint64_t) vpage, false);
@@ -288,18 +282,16 @@ pml4_set_dirty (uint64_t *pml4, const void *vpage, bool dirty) {
 	}
 }
 
-/* Returns true if the PTE for virtual page VPAGE in PML4 has been
- * accessed recently, that is, between the time the PTE was
- * installed and the last time it was cleared.  Returns false if
- * PML4 contains no PTE for VPAGE. */
+/* PML4의 가상 페이지 VPAGE에 대한 PTE가 최근에 액세스된 경우, 
+ * 즉 PTE가 설치된 시점과 마지막으로 삭제된 시점 사이에 액세스된 경우 true를 반환합니다.
+ * PML4에 VPAGE에 대한 PTE가 없는 경우 false를 반환합니다. */
 bool
 pml4_is_accessed (uint64_t *pml4, const void *vpage) {
 	uint64_t *pte = pml4e_walk (pml4, (uint64_t) vpage, false);
 	return pte != NULL && (*pte & PTE_A) != 0;
 }
 
-/* Sets the accessed bit to ACCESSED in the PTE for virtual page
-   VPAGE in PD. */
+/* PD의 가상 페이지 VPAGE에 대해 PTE의 액세스 비트를 ACCESSED로 설정합니다. */
 void
 pml4_set_accessed (uint64_t *pml4, const void *vpage, bool accessed) {
 	uint64_t *pte = pml4e_walk (pml4, (uint64_t) vpage, false);

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -134,7 +134,6 @@ page_fault (struct intr_frame *f) {
 	   be assured of reading CR2 before it changed). */
 	intr_enable ();
 
-
 	/* Determine cause. */
 	not_present = (f->error_code & PF_P) == 0;
 	write = (f->error_code & PF_W) != 0;

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -139,7 +139,6 @@ page_fault (struct intr_frame *f) {
 	not_present = (f->error_code & PF_P) == 0;
 	write = (f->error_code & PF_W) != 0;
 	user = (f->error_code & PF_U) != 0;
-	exit(-1);
 #ifdef VM
 	/* For project 3 and later. */
 	if (vm_try_handle_fault (f, fault_addr, user, write, not_present))
@@ -148,6 +147,7 @@ page_fault (struct intr_frame *f) {
 
 	/* Count page faults. */
 	page_fault_cnt++;
+	exit(-1);
 
 	/* If the fault is true fault, show info and exit. */
 	// printf ("Page fault at %p: %s error %s page in %s context.\n",

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -84,8 +84,12 @@ kill (struct intr_frame *f) {
 		case SEL_UCSEG:
 			/* User's code segment, so it's a user exception, as we
 			   expected.  Kill the user process.  */
-			printf("%s: exit(-1)\n", t->name);
-			t->exit_status = -1;
+			// printf("%s: exit(-1)\n", t->name);
+			// t->exit_status = -1;
+			// thread_exit();
+			printf("%s: dying due to interrupt %#04llx (%s).\n",
+			   thread_name(), f->vec_no, intr_name(f->vec_no));
+			intr_dump_frame(f);
 			thread_exit();
 
 		case SEL_KCSEG:
@@ -149,10 +153,10 @@ page_fault (struct intr_frame *f) {
 	exit(-1);
 
 	/* If the fault is true fault, show info and exit. */
-	// printf ("Page fault at %p: %s error %s page in %s context.\n",
-	// 		fault_addr,
-	// 		not_present ? "not present" : "rights violation",
-	// 		write ? "writing" : "reading",
-	// 		user ? "user" : "kernel");
-	// kill (f);
+	printf ("Page fault at %p: %s error %s page in %s context.\n",
+			fault_addr,
+			not_present ? "not present" : "rights violation",
+			write ? "writing" : "reading",
+			user ? "user" : "kernel");
+	kill (f);
 }

--- a/userprog/exception.c
+++ b/userprog/exception.c
@@ -139,15 +139,14 @@ page_fault (struct intr_frame *f) {
 	intr_enable ();
 
 	/* Determine cause. */
-	not_present = (f->error_code & PF_P) == 0;
-	write = (f->error_code & PF_W) != 0;
-	user = (f->error_code & PF_U) != 0;
+	not_present = (f->error_code & PF_P) == 0;     // 페이지 존재 안함 fault인지 여부
+	write = (f->error_code & PF_W) != 0;           // write 요청인지 여부
+	user = (f->error_code & PF_U) != 0;            // user mode에서 발생했는지 여부
 #ifdef VM
 	/* For project 3 and later. */
 	if (vm_try_handle_fault (f, fault_addr, user, write, not_present))
 		return;
 #endif
-
 	/* Count page faults. */
 	page_fault_cnt++;
 	exit(-1);

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -789,19 +789,22 @@ static bool
 setup_stack (struct intr_frame *if_) {
 	bool success = false;
 	void *stack_lower_bound = (void *) (((uint8_t *) USER_STACK) - PGSIZE);
+
+	/* TODO: stack_bottom에 스택을 매핑하고 페이지를 즉시 요청하세요.
+	 * TODO: 성공하면, rsp를 그에 맞게 설정하세요.
+	 * TODO: 페이지가 스택임을 표시해야 합니다.
+	 * TODO: Your code goes here */
 	
 	/* 1) stack_bottom에 페이지를 하나 할당받는다.
 	 * VM_MARKER_0: 스택이 저장된 메모리 페이지임을 식별하기 위해 추가
 	 * writable: argument_stack()에서 값을 넣어야 하니 True */
-	if (vm_alloc_page(VM_ANON | VM_MARKER_0, stack_lower_bound, 1)) {
+	if (vm_alloc_page_with_initializer(VM_ANON | VM_MARKER_0, stack_lower_bound, 1, NULL, NULL))
+	{
 		// 2) 할당 받은 페이지에 바로 물리 프레임을 매핑한다.
 		success = vm_claim_page(stack_lower_bound);
-
-		if (success) {
+		if (success)
 			// 3) rsp를 변경한다. (argument_stack에서 이 위치부터 인자를 push한다.)
 			if_->rsp = USER_STACK;
-			thread_current()->stack_lower_bound = stack_lower_bound;
-		}
 	}
 	return success;
 }

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -21,6 +21,7 @@
 #include "lib/stdio.h"
 #include "intrinsic.h"
 #include "threads/synch.h"
+#include "userprog/syscall.h"
 #ifdef VM
 #include "vm/vm.h"
 #include "vm/file.h"
@@ -174,19 +175,21 @@ __do_fork (void *aux) {
         goto error;
 #endif
 
-	if (parent->fd_idx >= FDCOUNT_LIMIT)
-        goto error;
+if (parent->fd_idx >= FDCOUNT_LIMIT)
+goto error;
 
-    current->fd_idx = parent->fd_idx;  // fdt 및 idx 복제
+	lock_acquire(&filesys_lock);
     for (int fd = 3; fd < parent->fd_idx; fd++) {
-        if (parent->fd_table[fd] == NULL)
-            continue;
+		if (parent->fd_table[fd] == NULL)
+		continue;
         current->fd_table[fd] = file_duplicate(parent->fd_table[fd]);
     }
-
+	lock_release(&filesys_lock);
+	current->fd_idx = parent->fd_idx;  // fdt 및 idx 복제
+	
     sema_up(&current->fork_sema);  // fork 프로세스가 정상적으로 완료됐으므로 현재 fork용 sema unblock
-
-    process_init();
+    
+	process_init();
 
     /* Finally, switch to the newly created process. */
     if (succ)
@@ -227,17 +230,24 @@ process_exec (void *f_name) {
         argv[argc++] = arg;
 	
 	/* And then load the binary */
+	bool is_lock_held = lock_held_by_current_thread(&filesys_lock);
+	if (!is_lock_held)
+		lock_acquire(&filesys_lock);
 	success = load(file_name, &_if);
+	if (!is_lock_held)
+		lock_release(&filesys_lock);
 
-	if (!success)
-        return -1;
-
-    argument_stack(argv, argc, &_if);
-
-    palloc_free_page(file_name);
-
+	if (!success) {
+		palloc_free_page(file_name);
+		return -1;
+	}
+	argument_stack(argv, argc, &_if);
+		
+	_if.R.rdi = argc;
+	_if.R.rsi = (char *)_if.rsp + 8;
 
 	/* Start switched process. */
+	palloc_free_page(file_name);
 	do_iret (&_if);
 	NOT_REACHED ();
 }
@@ -302,6 +312,10 @@ process_wait (tid_t child_tid) {
 void
 process_exit (void) {
 	struct thread *curr = thread_current();
+
+	bool is_lock_held = lock_held_by_current_thread(&filesys_lock);
+	if (!is_lock_held)
+		lock_acquire(&filesys_lock);
 	for (int fd = 0; fd < curr->fd_idx; fd++)  // FDT 비우기
         close(fd);
 
@@ -312,6 +326,8 @@ process_exit (void) {
     process_cleanup();
 
     sema_up(&curr->wait_sema);  // 자식 프로세스가 종료될 때까지 대기하는 부모에게 signal
+	if (!is_lock_held)
+		lock_release(&filesys_lock);
     sema_down(&curr->exit_sema);  // 부모 프로세스가 종료될 떄까지 대기
 }
 

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -23,6 +23,7 @@
 #include "threads/synch.h"
 #ifdef VM
 #include "vm/vm.h"
+#include "vm/file.h"
 #endif
 
 static void process_cleanup (void);
@@ -407,7 +408,7 @@ struct ELF64_PHDR {
 
 static bool setup_stack (struct intr_frame *if_);
 static bool validate_segment (const struct Phdr *, struct file *);
-static bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
+bool load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes,
 		bool writable);
 
@@ -598,7 +599,7 @@ static bool install_page (void *upage, void *kpage, bool writable);
  *
  * Return true if successful, false if a memory allocation error
  * or disk read error occurs. */
-static bool
+bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
 		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
 	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
@@ -680,84 +681,87 @@ install_page (void *upage, void *kpage, bool writable) {
  * If you want to implement the function for only project 2, implement it on the
  * upper block. */
 
-struct lazy_load_arg {
-	struct file *file;
-	off_t ofs;
-	uint32_t read_bytes;
-	uint32_t zero_bytes;
-};
-
-
 /* 25.06.01 고재웅 작성 
- * aux를 인자로 받는데 이 aux 위에 정의된 lazy_load_arg를 받는다. 
- * 이 lazy_load_arg는 load_segment에서 저장된다.
+ * 25.06.02 정진영 수정 (주석 추가)
+ * 
+ * 이 함수는 페이지 폴트 시 호출되며,
+ * 해당 주소에 처음 접근할 때 데이터를 로딩한다.
+ *
+ * aux는 load_segment()에서 설정한 lazy_load_arg 구조체 포인터다.
+ * 이 구조체에는 파일, 읽기 오프셋, 읽을 바이트 수, 0으로 채울 바이트 수가 담겨 있다.
  */
-static bool
+bool
 lazy_load_segment (struct page *page, void *aux) {
-	/* TODO: Load the segment from the file */
-	/* TODO: This called when the first page fault occurs on address VA. */
-	/* TODO: VA is available when calling this function. */
+	ASSERT(page->frame != NULL);
+
+	// aux 포인터를 원래의 lazy_load_arg 타입으로 변환
 	struct lazy_load_arg *lazy_load_arg = (struct lazy_load_arg *)aux;
-	// 1) 파일의 position을 ofs으로 지정한다.
+	
+	// 1. 파일의 현재 위치를 읽기 시작 위치(ofs)로 이동
 	file_seek(lazy_load_arg->file, lazy_load_arg->ofs);
-	// 2) 파일을 read_bytes만큼 물리 프레임에 읽어 들인다.
-	if (file_read(lazy_load_arg->file, page->frame->kva, lazy_load_arg->read_bytes) != (int)(lazy_load_arg->read_bytes))
-	{
+
+	// 2. 파일에서 read_bytes 만큼 데이터를 읽어서 이 페이지의 프레임(kva)에 복사
+	if (file_read(lazy_load_arg->file, page->frame->kva, lazy_load_arg->read_bytes) 
+					!= (int)(lazy_load_arg->read_bytes)) {
+		// 읽기 실패 시, 할당된 프레임을 반환하고 false 리턴
 		palloc_free_page(page->frame->kva);
 		return false;
 	}
-	// 3) 다 읽은 지점부터 zero_bytes만큼 0으로 채운다.
+	// 3. 남은 공간은 zero_bytes만큼 0으로 초기화
 	memset(page->frame->kva + lazy_load_arg->read_bytes, 0, lazy_load_arg->zero_bytes);
 
+	// 성공적으로 로딩 완료
 	return true;
 }
 
-/* 25.06.01 고재웅 작성 */
-/* Loads a segment starting at offset OFS in FILE at address
- * UPAGE.  In total, READ_BYTES + ZERO_BYTES bytes of virtual
- * memory are initialized, as follows:
+/* 25.06.01 고재웅 작성
+ * 25.06.02 정진영 수정 (주석 추가)
+ * 25.06.04 정진영 수정 (file_reopen())
  *
- * - READ_BYTES bytes at UPAGE must be read from FILE
- * starting at offset OFS.
+ * 파일 FILE의 OFS 오프셋에서 시작하는 segment를 가상 주소 UPAGE부터 로드한다.
  *
- * - ZERO_BYTES bytes at UPAGE + READ_BYTES must be zeroed.
+ * 총 READ_BYTES + ZERO_BYTES 만큼의 가상 메모리를 초기화하며, 그 방식은 다음과 같다:
+ * - UPAGE에서 시작하여 READ_BYTES 만큼의 바이트는 FILE에서 읽는다.
+ * - 그 다음 ZERO_BYTES 만큼의 바이트는 0으로 채운다.
  *
- * The pages initialized by this function must be writable by the
- * user process if WRITABLE is true, read-only otherwise.
- *
- * Return true if successful, false if a memory allocation error
- * or disk read error occurs. */
-static bool
+ * WRITABLE이 true이면 해당 페이지는 사용자 쓰기 가능해야 하며,
+ * false이면 읽기 전용이어야 한다.
+ * 성공 시 true, 메모리 할당 오류나 디스크 읽기 오류 시 false를 반환한다.
+ */
+bool
 load_segment (struct file *file, off_t ofs, uint8_t *upage,
-		uint32_t read_bytes, uint32_t zero_bytes, bool writable) {
-	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);
-	ASSERT (pg_ofs (upage) == 0);
-	ASSERT (ofs % PGSIZE == 0);
+		uint32_t read_bytes, uint32_t zero_bytes, bool writable) 
+{
+	ASSERT ((read_bytes + zero_bytes) % PGSIZE == 0);	// 전체 바이트 수는 페이지 단위(배수)로 정렬되어 있어야 함
+	ASSERT (pg_ofs (upage) == 0);						// upage는 페이지 정렬된 주소여야 함
+	ASSERT (ofs % PGSIZE == 0);							// 파일 오프셋도 페이지 크기의 배수여야 함
 
 	while (read_bytes > 0 || zero_bytes > 0) {
-		/* Do calculate how to fill this page.
-		 * We will read PAGE_READ_BYTES bytes from FILE
-		 * and zero the final PAGE_ZERO_BYTES bytes. */
+		/* 이 페이지를 채우는 방법을 계산합니다. 
+		 * 파일에서 PAGE_READ_BYTES 만큼 읽고 나머지 PAGE_ZERO_BYTES 만큼 0으로 채웁니다. */
 		size_t page_read_bytes = read_bytes < PGSIZE ? read_bytes : PGSIZE;
-		size_t page_zero_bytes = PGSIZE - page_read_bytes;
+		size_t page_zero_bytes = PGSIZE - page_read_bytes;					
 
-		/* TODO: Set up aux to pass information to the lazy_load_segment. */
+		// lazy load용 정보 구조체 생성 및 초기화
 		struct lazy_load_arg *lazy_load_arg = (struct lazy_load_arg *)malloc(sizeof(struct lazy_load_arg));
-		lazy_load_arg->file = file;					 // 내용이 담긴 파일 객체
-		lazy_load_arg->ofs = ofs;					 // 이 페이지에서 읽기 시작할 위치
-		lazy_load_arg->read_bytes = page_read_bytes; // 이 페이지에서 읽어야 하는 바이트 수
-		lazy_load_arg->zero_bytes = page_zero_bytes; // 이 페이지에서 read_bytes만큼 읽고 공간이 남아 0으로 채워야 하는 바이트 수
+		lazy_load_arg->file = file_reopen(file);					 // 읽어올 파일
+		lazy_load_arg->ofs = ofs;					 // 이 페이지에서 읽기 시작할 파일 오프셋
+		lazy_load_arg->read_bytes = page_read_bytes; // 읽어올 바이트 수
+		lazy_load_arg->zero_bytes = page_zero_bytes; // read_bytes만큼 읽고 공간이 남아 0으로 채워야 하는 바이트 수
 
-		if (!vm_alloc_page_with_initializer(VM_ANON, upage, writable, lazy_load_segment, lazy_load_arg))
-			return false;
+		// 실제 페이지를 lazy 방식으로 등록
+		if (!vm_alloc_page_with_initializer(VM_ANON, upage, writable, lazy_load_segment, lazy_load_arg)) {
+			free(lazy_load_arg);  // 누수 방지
+			return false;	// 실패 시 바로 종료
+		}
 
-		/* Advance. */
+		// 다음 페이지로 이동(반복)을 위해 읽어들인 만큼 값을 갱신
 		read_bytes -= page_read_bytes;
 		zero_bytes -= page_zero_bytes;
 		upage += PGSIZE;
 		ofs += page_read_bytes;
 	}
-	return true;
+	return true;	// 모든 페이지 성공적으로 등록됨
 }
 
 /* 25.06.01 고재웅 작성 */
@@ -769,10 +773,10 @@ setup_stack (struct intr_frame *if_) {
 	bool success = false;
 	void *stack_bottom = (void *) (((uint8_t *) USER_STACK) - PGSIZE);
 
-	/* TODO: Map the stack on stack_bottom and claim the page immediately.
-	 * TODO: If success, set the rsp accordingly.
-	 * TODO: You should mark the page is stack. */
-	/* TODO: Your code goes here */
+	/* TODO: stack_bottom에 스택을 매핑하고 페이지를 즉시 요청하세요.
+	 * TODO: 성공하면, rsp를 그에 맞게 설정하세요.
+	 * TODO: 페이지가 스택임을 표시해야 합니다.
+	 * TODO: Your code goes here */
 	
 	/* 1) stack_bottom에 페이지를 하나 할당받는다.
 	 * VM_MARKER_0: 스택이 저장된 메모리 페이지임을 식별하기 위해 추가

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -752,6 +752,7 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 	ASSERT (pg_ofs (upage) == 0);						// upage는 페이지 정렬된 주소여야 함
 	ASSERT (ofs % PGSIZE == 0);							// 파일 오프셋도 페이지 크기의 배수여야 함
 
+	file_seek (file, ofs);
 	while (read_bytes > 0 || zero_bytes > 0) {
 		/* 이 페이지를 채우는 방법을 계산합니다. 
 		 * 파일에서 PAGE_READ_BYTES 만큼 읽고 나머지 PAGE_ZERO_BYTES 만큼 0으로 채웁니다. */
@@ -787,23 +788,20 @@ load_segment (struct file *file, off_t ofs, uint8_t *upage,
 static bool
 setup_stack (struct intr_frame *if_) {
 	bool success = false;
-	void *stack_bottom = (void *) (((uint8_t *) USER_STACK) - PGSIZE);
-
-	/* TODO: stack_bottom에 스택을 매핑하고 페이지를 즉시 요청하세요.
-	 * TODO: 성공하면, rsp를 그에 맞게 설정하세요.
-	 * TODO: 페이지가 스택임을 표시해야 합니다.
-	 * TODO: Your code goes here */
+	void *stack_lower_bound = (void *) (((uint8_t *) USER_STACK) - PGSIZE);
 	
 	/* 1) stack_bottom에 페이지를 하나 할당받는다.
 	 * VM_MARKER_0: 스택이 저장된 메모리 페이지임을 식별하기 위해 추가
 	 * writable: argument_stack()에서 값을 넣어야 하니 True */
-	if (vm_alloc_page_with_initializer(VM_ANON | VM_MARKER_0, stack_bottom, 1, NULL, NULL))
-	{
+	if (vm_alloc_page(VM_ANON | VM_MARKER_0, stack_lower_bound, 1)) {
 		// 2) 할당 받은 페이지에 바로 물리 프레임을 매핑한다.
-		success = vm_claim_page(stack_bottom);
-		if (success)
+		success = vm_claim_page(stack_lower_bound);
+
+		if (success) {
 			// 3) rsp를 변경한다. (argument_stack에서 이 위치부터 인자를 push한다.)
 			if_->rsp = USER_STACK;
+			thread_current()->stack_lower_bound = stack_lower_bound;
+		}
 	}
 	return success;
 }

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -11,6 +11,7 @@
 #include "intrinsic.h"
 #include "userprog/process.h"
 #include "threads/palloc.h"
+#include "vm/vm.h"
 #include <string.h>
 
 void syscall_entry (void);
@@ -52,17 +53,14 @@ void check_address(void *addr)
 
     #ifdef VM
         /* SPT에 존재하지 않는다면 잘못된 접근 */
-        if (spt_find_page(&thread_current()->spt, addr) == NULL)
+        struct thread *t = thread_current();
+        if (spt_find_page(&t->spt, addr) == NULL)
             exit(-1);
     #else
         /* 페이지 테이블에서 직접 확인 (Project 2까지) */
-        if (pml4_get_page(&thread_current()->pml4, addr) == NULL)
+        if (pml4_get_page(thread_current()->pml4, addr) == NULL)
             exit(-1);
     #endif        
-    // if (addr == NULL)
-    //     exit(-1);
-    // if (!is_user_vaddr(addr))
-    //     exit(-1);
 }
 
 void

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -79,7 +79,7 @@ syscall_init (void) {
 /* The main system call interface */
 /* 25.06.03 정진영 수정 */
 void
-syscall_handler (struct intr_frame *f UNUSED) 
+syscall_handler (struct intr_frame *f) 
 {
     thread_current()->user_rsp = f->rsp;    // 현재 스레드에 유저 스택 포인터 저장
 
@@ -223,9 +223,44 @@ tid_t fork(const char *thread_name, struct intr_frame *f) {
     return process_fork(thread_name, f);  // 실제 유저 컨텍스트를 넘긴다
 }
 
+// int read(int fd, void *buffer, unsigned size) {
+// 	check_address(buffer);
+
+//     if (fd == 0) {  // 0(stdin) -> keyboard로 직접 입력
+//         int i = 0;  // 쓰레기 값 return 방지
+//         char c;
+//         unsigned char *buf = buffer;
+
+//         for (; i < size; i++) {
+//             c = input_getc();
+//             *buf++ = c;
+//             if (c == '\0')
+//                 break;
+//         }
+
+//         return i;
+//     }
+//     // 그 외의 경우
+//     if (fd < 3)  // stdout, stderr를 읽으려고 할 경우 & fd가 음수일 경우
+//         return -1;
+
+//     struct file *file = process_get_file(fd);
+//     off_t bytes = -1;
+
+//     if (file == NULL)  // 파일이 비어있을 경우
+//         return -1;
+
+//     lock_acquire(&filesys_lock);
+//     bytes = file_read(file, buffer, size);
+//     lock_release(&filesys_lock);
+
+//     return bytes;
+
+// }
+
 int read(int fd, void *buffer, unsigned size) {
 	check_address(buffer);
-
+    lock_acquire(&filesys_lock);
     if (fd == 0) {  // 0(stdin) -> keyboard로 직접 입력
         int i = 0;  // 쓰레기 값 return 방지
         char c;
@@ -237,27 +272,38 @@ int read(int fd, void *buffer, unsigned size) {
             if (c == '\0')
                 break;
         }
-
+        lock_release(&filesys_lock);
         return i;
     }
     // 그 외의 경우
     if (fd < 3)  // stdout, stderr를 읽으려고 할 경우 & fd가 음수일 경우
+    {
+        lock_release(&filesys_lock);
         return -1;
+    }
 
     struct file *file = process_get_file(fd);
     off_t bytes = -1;
 
     if (file == NULL)  // 파일이 비어있을 경우
+    {
+        lock_release(&filesys_lock);
         return -1;
+    }
 
-    lock_acquire(&filesys_lock);
+#ifdef VM
+    struct page *page = spt_find_page(&thread_current()->spt, buffer);
+    if (page && !page->writable){
+        lock_release(&filesys_lock);
+        exit(-1);
+    }
+#endif
     bytes = file_read(file, buffer, size);
     lock_release(&filesys_lock);
 
     return bytes;
 
 }
-
 
 // 파일 디스크럽터를 사용하여 파일의 크기를 가져오는 함수
 int filesize(int fd) {

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -24,6 +24,8 @@ void close (int fd);
 int wait(tid_t pid);
 void seek(int fd, unsigned position);
 int tell(int fd);
+void *mmap(void *addr, size_t length, int writable, int fd, off_t offset);
+void munmap(void *addr);
 
 /* System call.
  *
@@ -41,11 +43,23 @@ int tell(int fd);
 #define STDIN_FILENO 0
 #define STDOUT_FILENO 1
 
+/* 25.06.03 정진영 수정 */
 void check_address(void *addr)
 {
     // kernel VM 못가게, 할당된 page가 존재하도록(빈공간접근 못하게)
-    if (is_kernel_vaddr(addr) || addr == NULL || pml4_get_page(thread_current()->pml4, addr) == NULL)
+    if (!is_user_vaddr(addr) || addr == NULL)   // null이거나 커널 영역 접근 시
         exit(-1);
+
+    #ifdef VM
+        /* SPT에 존재하지 않는다면 잘못된 접근 */
+        struct thread *t = thread_current();
+        if (spt_find_page(&t->spt, addr) == NULL)
+            exit(-1);
+    #else
+        /* 페이지 테이블에서 직접 확인 (Project 2까지) */
+        if (pml4_get_page(thread_current()->pml4, addr) == NULL)
+            exit(-1);
+    #endif        
 }
 
 void
@@ -63,10 +77,13 @@ syscall_init (void) {
 }
 
 /* The main system call interface */
+/* 25.06.03 정진영 수정 */
 void
-syscall_handler (struct intr_frame *f UNUSED) {
-	switch (f->R.rax)
-	{
+syscall_handler (struct intr_frame *f UNUSED) 
+{
+    thread_current()->user_rsp = f->rsp;    // 현재 스레드에 유저 스택 포인터 저장
+
+	switch (f->R.rax) {
 	case SYS_HALT:
 		halt(); // 핀토스 종료
 		break;
@@ -109,6 +126,12 @@ syscall_handler (struct intr_frame *f UNUSED) {
 	case SYS_CLOSE:
 		close(f->R.rdi);
 		break;
+    case SYS_MMAP:
+        f->R.rax = mmap(f->R.rdi, f->R.rsi, f->R.rdx, f->R.r10, f->R.r8);
+        break;
+    case SYS_MUNMAP:
+        munmap(f->R.rdi);
+        break;
 	default:
 		exit(-1);
 	}
@@ -154,29 +177,44 @@ int write(int fd, const void *buffer, unsigned size) {
 }
 
 
-
 bool create (const char *file, unsigned initial_size){
 	check_address(file);
-    return filesys_create(file, initial_size);
+
+    lock_acquire(&filesys_lock);
+    bool success = filesys_create(file, initial_size);
+    lock_release(&filesys_lock);
+
+    return success;
 }
 
 bool remove (const char *file) {
 	check_address(file);
-	return filesys_remove(file);
+
+    lock_acquire(&filesys_lock);
+    bool success = filesys_remove(file);
+    lock_release(&filesys_lock);
+
+	return success;
 }
 
 int open (const char *file) {
 	check_address(file);
+
+    lock_acquire(&filesys_lock);
+
     struct file *newfile = filesys_open(file);
 
-    if (newfile == NULL)
+    if (newfile == NULL) {
+        lock_release(&filesys_lock);
         return -1;
+    }
 
     int fd = process_add_file(newfile);
 
-    if (fd == -1)
+    if (fd == -1) 
         file_close(newfile);
 
+    lock_release(&filesys_lock);
     return fd;
 }
 
@@ -261,8 +299,7 @@ void seek(int fd, unsigned position) {
 
 // fd에서 다음에 읽거나 쓸 바이트의 위치를 반환하는 함수
 int 
-tell(int fd) 
-{
+tell(int fd) {
     struct file *file = process_get_file(fd);
 
     if (fd < 3 || file == NULL)
@@ -271,11 +308,10 @@ tell(int fd)
     return file_tell(file);
 }
 
-
-
 // Close file descriptor fd.
 // Use void file_close(struct file *file).
-void close(int fd) {
+void 
+close(int fd) {
     struct file *file = process_get_file(fd);
 
     if (fd < 3 || file == NULL)
@@ -289,3 +325,49 @@ void close(int fd) {
 int wait(tid_t pid){
 	return process_wait(pid);
 };
+
+/* mmap은 파일의 내용을 메모리의 특정 주소 공간에 매팽하는 작업
+ * 파일을 읽는 대신, 해당 주소를 읽는 것만으로 파일 내용을 얻을 수 있도록 함
+ * 
+ * 페이지 테이블 연동: 가상 주소 ↔ 페이지 테이블 ↔ 물리 프레임
+ * 페이지 폴트 핸들러: 
+ * fd로 열린 파일의 offset 바이트부터 length 바이트만큼 프로세스 va의 addr부터 매핑 
+ * 매핑은 페이지 단위로 이루어짐
+ * 
+ * mmap(): 유저 인자로부터 커널 안전성 검사 수행 (권한, 정렬, 유효성 등)
+ * do_mmap(): mmap 로직 전체를 책임 (페이지 등록, lazy loading, file 재열기 포함)
+ */
+void *
+mmap (void *addr, size_t length, int writable, int fd, off_t offset) 
+{
+    if (fd == 0 || fd == 1) return NULL;
+
+    int file_size = filesize(fd);
+    if (file_size == 0 || length == 0) return NULL;
+
+    if ((uint64_t)addr == 0 || (uint64_t)addr % PGSIZE != 0 || !is_user_vaddr(addr)) return NULL;
+
+    /* 추가하면 좋을 검사 항목 */
+    // if (offset % PGSIZE != 0) return NULL;  // offset 정렬 확인
+
+    // if (!is_user_vaddr(addr + length - 1)) return NULL; // 매핑하려는 전체 주소 영역 유효성 (범위 검사)
+
+    // void *check = addr;     // 매핑하려는 주소 범위에 이미 페이지가 존재하는지 검사
+    // for (; check < addr + length; check += PGSIZE) {
+    //     if (spt_find_page(&thread_current()->spt, check))
+    //         return NULL;
+    // }
+
+    // if (spt_find_page(&thread_current()->spt, addr)) return NULL;   // 이건 왜 하는지 모르겠음
+
+    struct file *file = process_get_file(fd);
+    if (file == NULL) return NULL;
+    
+    return do_mmap(addr, length, writable, file, offset);
+}
+
+/* addr은 mmap으로 할당받은 시작주소 */
+void
+munmap (void *addr) {
+    do_munmap(addr);
+}

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -52,14 +52,17 @@ void check_address(void *addr)
 
     #ifdef VM
         /* SPT에 존재하지 않는다면 잘못된 접근 */
-        struct thread *t = thread_current();
-        if (spt_find_page(&t->spt, addr) == NULL)
+        if (spt_find_page(&thread_current()->spt, addr) == NULL)
             exit(-1);
     #else
         /* 페이지 테이블에서 직접 확인 (Project 2까지) */
-        if (pml4_get_page(thread_current()->pml4, addr) == NULL)
+        if (pml4_get_page(&thread_current()->pml4, addr) == NULL)
             exit(-1);
     #endif        
+    // if (addr == NULL)
+    //     exit(-1);
+    // if (!is_user_vaddr(addr))
+    //     exit(-1);
 }
 
 void
@@ -81,7 +84,7 @@ syscall_init (void) {
 void
 syscall_handler (struct intr_frame *f) 
 {
-    thread_current()->user_rsp = f->rsp;    // 현재 스레드에 유저 스택 포인터 저장
+    thread_current()->saved_user_rsp = f->rsp;    // 현재 스레드에 유저 스택 포인터 저장
 
 	switch (f->R.rax) {
 	case SYS_HALT:

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -224,42 +224,8 @@ tid_t fork(const char *thread_name, struct intr_frame *f) {
     return process_fork(thread_name, f);  // 실제 유저 컨텍스트를 넘긴다
 }
 
-// int read(int fd, void *buffer, unsigned size) {
-// 	check_address(buffer);
-
-//     if (fd == 0) {  // 0(stdin) -> keyboard로 직접 입력
-//         int i = 0;  // 쓰레기 값 return 방지
-//         char c;
-//         unsigned char *buf = buffer;
-
-//         for (; i < size; i++) {
-//             c = input_getc();
-//             *buf++ = c;
-//             if (c == '\0')
-//                 break;
-//         }
-
-//         return i;
-//     }
-//     // 그 외의 경우
-//     if (fd < 3)  // stdout, stderr를 읽으려고 할 경우 & fd가 음수일 경우
-//         return -1;
-
-//     struct file *file = process_get_file(fd);
-//     off_t bytes = -1;
-
-//     if (file == NULL)  // 파일이 비어있을 경우
-//         return -1;
-
-//     lock_acquire(&filesys_lock);
-//     bytes = file_read(file, buffer, size);
-//     lock_release(&filesys_lock);
-
-//     return bytes;
-
-// }
-
-int read(int fd, void *buffer, unsigned size) {
+int read(int fd, void *buffer, unsigned size) 
+{
 	check_address(buffer);
     lock_acquire(&filesys_lock);
     if (fd == 0) {  // 0(stdin) -> keyboard로 직접 입력
@@ -277,17 +243,17 @@ int read(int fd, void *buffer, unsigned size) {
         return i;
     }
     // 그 외의 경우
-    if (fd < 3)  // stdout, stderr를 읽으려고 할 경우 & fd가 음수일 경우
-    {
+    if (fd < 2) 
+    {   // stdout, stderr를 읽으려고 할 경우 & fd가 음수일 경우
         lock_release(&filesys_lock);
         return -1;
     }
-
+    
     struct file *file = process_get_file(fd);
     off_t bytes = -1;
 
-    if (file == NULL)  // 파일이 비어있을 경우
-    {
+    if (file == NULL)  
+    {   // 빈 파일, stdout, stderr를 읽으려고 할 경우
         lock_release(&filesys_lock);
         return -1;
     }
@@ -299,12 +265,51 @@ int read(int fd, void *buffer, unsigned size) {
         exit(-1);
     }
 #endif
+
     bytes = file_read(file, buffer, size);
     lock_release(&filesys_lock);
 
     return bytes;
-
 }
+
+// int 
+// read(int fd, void *buffer, unsigned length) 
+// {
+//     struct thread *curr = thread_current();
+//     check_address(buffer);
+// /** #project3-Stack Growth */
+// #ifdef VM
+//     struct page *page = spt_find_page(&thread_current()->spt, buffer);
+//     if (page && !page->writable)
+//         exit(-1);
+// #endif
+//     struct file *file = process_get_file(fd);
+
+//     if (file == 0) { 
+//         int i = 0; 
+//         char c;
+//         unsigned char *buf = buffer;
+
+//         for (; i < length; i++) {
+//             c = input_getc();
+//             *buf++ = c;
+//             if (c == '\0')
+//                 break;
+//         }
+//         return i;
+//     }
+
+//     if (file == NULL || file == 1 || file == 2)  // 빈 파일, stdout, stderr를 읽으려고 할 경우
+//         return -1;
+
+//     off_t bytes = -1;
+
+//     lock_acquire(&filesys_lock);
+//     bytes = file_read(file, buffer, length);
+//     lock_release(&filesys_lock);
+
+//     return bytes;
+// }
 
 // 파일 디스크럽터를 사용하여 파일의 크기를 가져오는 함수
 int filesize(int fd) {

--- a/vm/Makefile
+++ b/vm/Makefile
@@ -1,1 +1,8 @@
 include ../Makefile.kernel
+
+.PHONY: vm
+vm:
+	make clean && \
+	make -j && \
+	cd ./build && \
+	make check 2>&1 | tee build_log.txt

--- a/vm/Makefile
+++ b/vm/Makefile
@@ -1,1 +1,8 @@
 include ../Makefile.kernel
+
+.PHONY: vm
+userp:
+	make clean && \
+	make -j && \
+	cd ./build && \
+	make check 2>&1 | tee build_log.txt

--- a/vm/Makefile
+++ b/vm/Makefile
@@ -1,8 +1,1 @@
 include ../Makefile.kernel
-
-.PHONY: vm
-userp:
-	make clean && \
-	make -j && \
-	cd ./build && \
-	make check 2>&1 | tee build_log.txt

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -1,6 +1,7 @@
 /* anon.c: 디스크 이미지가 아닌 페이지(익명 페이지)의 구현 */
 
 #include "vm/vm.h"
+#include "include/threads/vaddr.h"
 #include "devices/disk.h"
 
 /* DO NOT MODIFY BELOW LINE */

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -1,4 +1,4 @@
-/* anon.c: Implementation of page for non-disk image (a.k.a. anonymous page). */
+/* anon.c: 디스크 이미지가 아닌 페이지(익명 페이지)의 구현 */
 
 #include "vm/vm.h"
 #include "devices/disk.h"

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -18,17 +18,17 @@ static const struct page_operations anon_ops = {
 	.type = VM_ANON,
 };
 
-/* 익명 페이지를 위한 데이터를 초기화하는 함수 */
+/* Initialize the data for anonymous pages */
 void
 vm_anon_init (void) {
-	/* TODO: 스왑 디스크를 설정해야 합니다. */
+	/* TODO: Set up the swap_disk. */
 	swap_disk = NULL;
 }
 
-/* anonymous 페이지 타입의 초기화를 수행하는 함수 */
+/* Initialize the file mapping */
 bool
 anon_initializer (struct page *page, enum vm_type type, void *kva) {
-	/* 페이지에 anon 페이지 핸들러를 설정합니다. */
+	/* Set up the handler */
 	page->operations = &anon_ops;
 
 	struct anon_page *anon_page = &page->anon;

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -18,17 +18,17 @@ static const struct page_operations anon_ops = {
 	.type = VM_ANON,
 };
 
-/* Initialize the data for anonymous pages */
+/* 익명 페이지를 위한 데이터를 초기화하는 함수 */
 void
 vm_anon_init (void) {
-	/* TODO: Set up the swap_disk. */
+	/* TODO: 스왑 디스크를 설정해야 합니다. */
 	swap_disk = NULL;
 }
 
-/* Initialize the file mapping */
+/* anonymous 페이지 타입의 초기화를 수행하는 함수 */
 bool
 anon_initializer (struct page *page, enum vm_type type, void *kva) {
-	/* Set up the handler */
+	/* 페이지에 anon 페이지 핸들러를 설정합니다. */
 	page->operations = &anon_ops;
 
 	struct anon_page *anon_page = &page->anon;

--- a/vm/file.c
+++ b/vm/file.c
@@ -1,6 +1,14 @@
 /* file.c: Implementation of memory backed file object (mmaped object). */
 
+#include <stdlib.h>
 #include "vm/vm.h"
+#include "threads/mmu.h"
+#include "threads/vaddr.h"
+#include "userprog/process.h"
+#include "userprog/syscall.h"
+#include "vm/file.h"
+
+struct lock filesys_lock;
 
 static bool file_backed_swap_in (struct page *page, void *kva);
 static bool file_backed_swap_out (struct page *page);
@@ -16,7 +24,14 @@ static const struct page_operations file_ops = {
 
 /* The initializer of file vm */
 void
-vm_file_init (void) {
+vm_file_init (void) 
+{
+	/* 전역 자료구조 초기화 */
+	/** TODO: mmap 리스트 초기화
+	 * mmap으로 만들어진 페이지를 리스트로 관리하면
+	 * munmmap 시에 더 빠르게 할 수 있을 듯 합니다
+	 *
+	 */
 }
 
 /* Initialize the file backed page */
@@ -26,33 +41,151 @@ file_backed_initializer (struct page *page, enum vm_type type, void *kva) {
 	page->operations = &file_ops;
 
 	struct file_page *file_page = &page->file;
+	/** TODO: file 백업 정보를 초기화
+	 * file_page에 어떤 정보가 있는지에 따라 다름
+	 * 타입도 변환?
+	 */
 }
 
-/* Swap in the page by read contents from the file. */
+/* 파일에서 내용을 읽어와 페이지를 스왑인합니다. */
 static bool
-file_backed_swap_in (struct page *page, void *kva) {
+file_backed_swap_in(struct page *page, void *kva)
+{
 	struct file_page *file_page UNUSED = &page->file;
+	// swap_in을 위한 버퍼
+	void *buffer[PGSIZE];
+	/** TODO: 파일에서 정보를 읽어와 kva에 복사하세요
+	 * aux에 저장된 백업 정보를 사용하세요
+	 * file_open과 read를 사용하면 될 것 같아요
+	 * 파일 시스템 동기화가 필요할수도 있어요
+	 * 필요시 file_backed_initializer를 수정하세요
+	 */
 }
 
-/* Swap out the page by writeback contents to the file. */
+/* 페이지의 내용을 파일에 기록(writeback)하여 스왑아웃합니다. */
 static bool
-file_backed_swap_out (struct page *page) {
+file_backed_swap_out(struct page *page)
+{
 	struct file_page *file_page UNUSED = &page->file;
+	/** TODO: dirty bit 확인해서 write back
+	 * pml4_is_dirty를 사용해서 dirty bit를 확인하세요
+	 * write back을 할 때는 aux에 저장된 파일 정보를 사용
+	 * file_write를 사용하면 될 것 같아요
+	 * dirty_bit 초기화 (pml4_set_dirty)
+	 */
 }
 
-/* Destory the file backed page. PAGE will be freed by the caller. */
+/* 파일 기반 페이지를 소멸시킵니다. PAGE는 호출자가 해제합니다. */
 static void
-file_backed_destroy (struct page *page) {
+file_backed_destroy(struct page *page)
+{
 	struct file_page *file_page UNUSED = &page->file;
+	/** TODO: dirty_bit 확인 후 write_back
+	 * pml4_is_dirty를 사용해서 dirty bit 확인
+	 * write back을 할 때는 aux에 저장된 파일 정보를 사용
+	 * file_write를 사용하면 될 것 같아요
+	 */
 }
 
-/* Do the mmap */
+// struct lazy_load_arg *
+// make_arg(struct file *file, off_t ofs, size_t read_bytes)
+// {
+// 	struct lazy_load_info *arg = malloc(sizeof(struct lazy_load_arg));
+// 	if (!arg) return NULL;
+
+// 	arg->file = file;
+// 	arg->ofs = ofs;
+// 	arg->read_bytes = read_bytes;
+// 	arg->zero_bytes = (read_bytes < PGSIZE) ? PGSIZE - read_bytes : 0;
+
+// 	return arg;
+// }
+
+/* do_mmap(): mmap 로직 전체를 책임 (페이지 등록, lazy loading, file 재열기 포함) 
+ * 
+ * lazy loading으로 할당
+ * 파일에 대한 독립적인 참조
+ * 여러 페이지에 매핑되는 파일 처리
+ */
 void *
-do_mmap (void *addr, size_t length, int writable,
-		struct file *file, off_t offset) {
+do_mmap(void *addr, size_t length, int writable, struct file *file, off_t offset)
+{
+	void *start_addr = addr;				// 성공 시 반환할 원래 가상 주소
+	int mmap_idx = 0;  						// 각 페이지에 부여할 mmap_idx
+
+	// 파일 재열기 → 독립된 file 객체 필요 (close(fd)와 무관하게 파일 내용을 유지)
+	// 파일 시스템 작업이므로 동기화를 위해 전역 filesys_lock 획득 필요
+	lock_acquire(&filesys_lock);			
+	struct file *reopened_file = file_reopen(file);	
+	lock_release(&filesys_lock);			
+
+	if (reopened_file == NULL) return NULL;
+
+	// 실제로 읽어야 할 바이트 수: 요청한 길이와 파일 크기 중 더 작은 값
+	// 페이지 보정용 zero padding 계산
+	size_t read_bytes = (file_length(reopened_file) < length) ? file_length(reopened_file) : length;
+	size_t zero_bytes = (read_bytes % PGSIZE == 0) ? 0 : PGSIZE - (read_bytes % PGSIZE);
+	
+	// 전체 매핑 범위에 이미 매핑된 페이지가 있는지 충돌 검사
+	for (void *check = addr; check < addr + read_bytes + zero_bytes; check += PGSIZE) {
+		if (spt_find_page(&thread_current()->spt, check) != NULL)
+			return NULL;
+	}
+
+	// 정렬 조건 검사
+	ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
+	ASSERT(pg_ofs(addr) == 0);
+	ASSERT(offset % PGSIZE == 0);
+
+	// 페이지 단위로 매핑 수행
+	size_t total_bytes = read_bytes + zero_bytes;
+	while (total_bytes > 0) 
+	{
+		// 현재 페이지에서 실제로 읽을 바이트 수와 남은 공간 zero padding 계산
+		size_t page_read_bytes = (read_bytes < PGSIZE) ? read_bytes : PGSIZE;
+		size_t page_zero_bytes = PGSIZE - page_read_bytes;
+
+		// lazy load용 인자 구조체 생성
+		struct lazy_load_arg *aux = malloc(sizeof(struct lazy_load_arg));
+		if (aux == NULL) {
+			file_close(reopened_file);
+			return NULL;
+		}
+
+		aux->file = reopened_file;
+		aux->ofs = offset;
+		aux->read_bytes = page_read_bytes;
+		aux->zero_bytes = page_zero_bytes;
+
+		// lazy load로 VM_FILE 페이지 등록
+		if (!vm_alloc_page_with_initializer(VM_FILE, addr, writable, lazy_load_segment, aux)) 
+		{
+			free(aux);
+			file_close(reopened_file);
+			return NULL;
+		}
+
+		// 해당 주소에 실제로 할당된 page 구조체를 가져와 mmap_idx 저장
+		struct page *p = spt_find_page(&thread_current()->spt, addr);
+		if (p != NULL)
+			p->mmap_idx = mmap_idx++;
+
+		// 다음 페이지로 이동
+		read_bytes -= page_read_bytes;
+		zero_bytes -= page_zero_bytes;
+		addr += PGSIZE;
+		offset += page_read_bytes;
+	}	
+
+	return start_addr;
 }
 
-/* Do the munmap */
-void
-do_munmap (void *addr) {
+/** TODO: mmap으로 매핑된 모든 페이지를 없애야함
+ * 1. SPT에서 제거
+ * 2. 물리 페이지에서도 제거
+ * 3. 매핑 카운트나 page 구조체 내의 카운트를 사용해서 제거
+ */
+void do_munmap(void *addr) 
+{
+	
 }

--- a/vm/file.c
+++ b/vm/file.c
@@ -41,10 +41,15 @@ file_backed_initializer (struct page *page, enum vm_type type, void *kva) {
 	page->operations = &file_ops;
 
 	struct file_page *file_page = &page->file;
-	/** TODO: file 백업 정보를 초기화
-	 * file_page에 어떤 정보가 있는지에 따라 다름
-	 * 타입도 변환?
-	 */
+
+	// TODO: page에 page->uninit.aux에 들어있는 정보를 구조체로 형변환 (ex. lazy_load_arg *)
+
+	struct lazy_load_arg *aux = (struct lazy_load_arg *)page->uninit.aux;
+	file_page->file = aux->file;
+	file_page->ofs = aux->ofs;
+	file_page->read_bytes = aux->read_bytes;
+	file_page->zero_bytes = aux->zero_bytes;
+	return true;
 }
 
 /* 파일에서 내용을 읽어와 페이지를 스왑인합니다. */
@@ -79,12 +84,14 @@ file_backed_swap_out(struct page *page)
 static void
 file_backed_destroy(struct page *page)
 {
-	struct file_page *file_page UNUSED = &page->file;
-	/** TODO: dirty_bit 확인 후 write_back
-	 * pml4_is_dirty를 사용해서 dirty bit 확인
-	 * write back을 할 때는 aux에 저장된 파일 정보를 사용
-	 * file_write를 사용하면 될 것 같아요
-	 */
+	struct file_page *file_page = &page->file;
+
+	 // 해당 페이지가 dirty 상태인지 확인
+	 if (pml4_is_dirty(thread_current()->pml4, page->va)) {
+		file_write_at(file_page->file, page->va, file_page->read_bytes, file_page->ofs);
+		pml4_set_dirty(thread_current()->pml4, page->va, 0);
+	 }
+	 pml4_clear_page(thread_current()->pml4, page->va);
 }
 
 // struct lazy_load_arg *
@@ -187,5 +194,27 @@ do_mmap(void *addr, size_t length, int writable, struct file *file, off_t offset
  */
 void do_munmap(void *addr) 
 {
-	
+	struct supplemental_page_table *spt = &thread_current()->spt;
+	struct page *page;
+
+	lock_acquire(&filesys_lock);		// 파일 시스템과의 동기화를 위해 전역 락 획득 (파일과 관련된 페이지일 수 있기 때문)	
+
+	page = spt_find_page(spt, addr);	// 현재 주소에 해당하는 페이지를 보조 페이지 테이블에서 검색
+	if (page == NULL) {					// 페이지가 존재하지 않으면 즉시 반환 (락 해제 후)
+		lock_release(&filesys_lock);
+		return;
+	}
+
+	int mmap_idx = page->mmap_idx;		// 이 페이지가 속한 mmap 영역의 전체 페이지 수를 가져옴
+
+	// mmap_idx 만큼 반복하며 페이지 해제 수행
+	for (int i = 0; i < mmap_idx; i++) {
+		struct page *target = spt_find_page(spt, addr);		// 현재 주소에 해당하는 페이지를 다시 찾음
+		if (target != NULL)				// 페이지가 존재한다면 보조 페이지 테이블에서 제거 (즉, unmap)
+			// destroy(target_page);
+			spt_remove_page(spt, target);					
+		addr += PGSIZE;					// 다음 페이지 주소로 이동 (페이지 크기만큼 증가)
+	}
+
+	lock_release(&filesys_lock);		// 락 해제 (모든 페이지 제거 후)
 }

--- a/vm/uninit.c
+++ b/vm/uninit.c
@@ -1,12 +1,11 @@
-/* uninit.c: Implementation of uninitialized page.
+/* uninit.c: 미초기화(uninitialized) 페이지의 구현
  *
- * All of the pages are born as uninit page. When the first page fault occurs,
- * the handler chain calls uninit_initialize (page->operations.swap_in).
- * The uninit_initialize function transmutes the page into the specific page
- * object (anon, file, page_cache), by initializing the page object,and calls
- * initialization callback that passed from vm_alloc_page_with_initializer
- * function.
- * */
+ * 현재 설계에서는, 모든 페이지가 초기화되지 않은 페이지로 설정되고,
+ * 첫 번째 페이지 폴트가 발생하면 핸들러 체인이 uninit_initialize를 호출합니다.
+ * uninit_initialize 함수(page->operations.swap_in)는 페이지 객체를 초기화하여 
+ * 해당 페이지를 특정 페이지 객체(anonymous page, file-backed page, page_cache)로 변환하고,
+ * vm_alloc_page_with_initializer 함수에서 전달된 초기화 콜백을 호출합니다.
+ */
 
 #include "vm/vm.h"
 #include "vm/uninit.h"
@@ -42,27 +41,26 @@ uninit_new (struct page *page, void *va, vm_initializer *init,
 	};
 }
 
-/* Initalize the page on first fault */
+/* 첫 번째 폴트 시 페이지를 초기화합니다 */
 static bool
 uninit_initialize (struct page *page, void *kva) {
 	struct uninit_page *uninit = &page->uninit;
 
-	/* Fetch first, page_initialize may overwrite the values */
+	/* 먼저 가져옵니다. page_initialize가 값을 덮어쓸 수 있습니다. */
 	vm_initializer *init = uninit->init;
 	void *aux = uninit->aux;
 
-	/* TODO: You may need to fix this function. */
+	/* TODO: 이 함수를 수정해야 할 수도 있습니다. */
 	return uninit->page_initializer (page, uninit->type, kva) &&
 		(init ? init (page, aux) : true);
 }
 
-/* Free the resources hold by uninit_page. Although most of pages are transmuted
- * to other page objects, it is possible to have uninit pages when the process
- * exit, which are never referenced during the execution.
- * PAGE will be freed by the caller. */
+/* uninit_page가 보유한 리소스를 해제합니다. 대부분의 페이지는 다른 페이지 객체로 변환되지만,
+ * 실행 중 한 번도 참조되지 않은 uninit 페이지가 프로세스 종료 시 남아 있을 수 있습니다.
+ * PAGE 자체는 호출자가 해제합니다. */
 static void
 uninit_destroy (struct page *page) {
 	struct uninit_page *uninit UNUSED = &page->uninit;
-	/* TODO: Fill this function.
-	 * TODO: If you don't have anything to do, just return. */
+	/* TODO: 이 함수를 구현하세요.
+	 * TODO: 특별히 할 일이 없다면 그냥 return 하세요. */
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -1,64 +1,70 @@
-/* vm.c: Generic interface for virtual memory objects. */
+/* vm.c: 
+ * 가상 메모리(Virtual Memory) 전반에 대한 인터페이스를 제공
+ */
 
 #include "threads/malloc.h"
 #include "vm/vm.h"
 #include "vm/inspect.h"
+#include "threads/mmu.h"
+
 /* 25.05.30 고재웅 작성 */
 #include <hash.h>
 #include "threads/vaddr.h"
 
-/* Initializes the virtual memory subsystem by invoking each subsystem's
- * intialize codes. */
-void
-vm_init (void) {
-	list_init(&frame_table);
-	vm_anon_init ();
-	vm_file_init ();
-#ifdef EFILESYS  /* For project 4 */
-	pagecache_init ();
+/* 각 서브시스템의 초기화 코드를 호출하여 가상 메모리 서브시스템을 초기화합니다. */
+void 
+vm_init (void)
+{
+	list_init(&frame_table);	/* 25.05.30 고재웅 작성 */
+	vm_anon_init();
+	vm_file_init();
+#ifdef EFILESYS /* For project 4 */
+	pagecache_init();
 #endif
-	register_inspect_intr ();
-	/* DO NOT MODIFY UPPER LINES. */
-	/* TODO: Your code goes here. */
+	register_inspect_intr();
+	/* 이 위쪽은 수정하지 마세요 !! */
+	/* TODO: 이 아래쪽부터 코드를 추가하세요 */
 }
 
-/* Get the type of the page. This function is useful if you want to know the
- * type of the page after it will be initialized.
- * This function is fully implemented now. */
+/* 페이지의 타입을 가져옵니다. 이 함수는 페이지가 초기화된 후 타입을 알고 싶을 때 유용합니다.
+ * 이 함수는 이미 완전히 구현되어 있습니다. */
 enum vm_type
-page_get_type (struct page *page) {
-	int ty = VM_TYPE (page->operations->type);
-	switch (ty) {
-		case VM_UNINIT:
-			return VM_TYPE (page->uninit.type);
-		default:
-			return ty;
+page_get_type(struct page *page)
+{
+	int ty = VM_TYPE(page->operations->type);
+	switch (ty)
+	{
+	case VM_UNINIT:
+		return VM_TYPE(page->uninit.type);
+	default:
+		return ty;
 	}
 }
 
 /* Helpers */
-static struct frame *vm_get_victim (void);
-static bool vm_do_claim_page (struct page *page);
-static struct frame *vm_evict_frame (void);
+static struct frame *vm_get_victim(void);
+static bool vm_do_claim_page(struct page *page);
+static struct frame *vm_evict_frame(void);
 
-/* Create the pending page object with initializer. If you want to create a
- * page, do not create it directly and make it through this function or
- * `vm_alloc_page`. */
-bool
-vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
-		vm_initializer *init, void *aux) {
+/* 초기화 함수와 함께 대기 중인 페이지 객체를 생성합니다. 페이지를 직접 생성하지 말고,
+ * 반드시 이 함수나 `vm_alloc_page`를 통해 생성하세요. */
+bool 
+vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
+									vm_initializer *init, void *aux)
+{
 
-	ASSERT (VM_TYPE(type) != VM_UNINIT)
+	ASSERT(VM_TYPE(type) != VM_UNINIT)
 
 	struct supplemental_page_table *spt = &thread_current ()->spt;
 	struct page *page = NULL;
+
 	/* Check wheter the upage is already occupied or not. */
 	if (spt_find_page (spt, upage) == NULL) {
-		/* TODO: 페이지를 생성하고, VM 유형에 따라 초기화 파일을 가져옵니다.
-		* TODO: 그런 다음 uninit_new를 호출하여 "uninit" 페이지 구조체를 생성합니다.
-		* TODO: uninit_new를 호출한 후 필드를 수정해야 합니다. */
+		/* TODO: 페이지를 생성하고, VM 유형에 따라 초기화 파일을 가져옵니다.Add commentMore actions
+		 * TODO: 그런 다음 uninit_new를 호출하여 "uninit" 페이지 구조체를 생성합니다.
+		 * TODO: uninit_new를 호출한 후 필드를 수정해야 합니다. */
 		page = malloc(sizeof(struct page));
-		if (page == NULL){
+		if (page == NULL) {
 			return false;
 		}
 		bool (*page_initializer) (struct page *, enum vm_type, void *kva) = NULL;
@@ -76,10 +82,9 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 		}
 		/* TODO: spt에 페이지를 삽입합니다. */
 		uninit_new(page, upage, init, type, aux, page_initializer);
-
 		page->writable = writable;
 
-		if (!spt_insert_page(spt, page)){
+		if (!spt_insert_page(spt, page)) {
 			return true;
 		}
 	}
@@ -91,8 +96,11 @@ err:
 }
 
 /* Find VA from spt and return page. On error, return NULL. */
+/* 가상 주소를 통해 SPT에서 페이지를 찾아 리턴합니다.
+ * 에러가 발생하면 NULL을 리턴하세요. */
 struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
+	struct page *page = NULL;
 	/* TODO: Fill this function. */
 	/* 25.05.30 고재웅 작성 */
 	struct page temp;
@@ -103,10 +111,11 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	return hash_entry(e, struct page, hash_elem);
 }
 
-/* Insert PAGE into spt with validation. */
+/* PAGE를 spt에 삽입하며 검증을 수행합니다. */
 bool
 spt_insert_page (struct supplemental_page_table *spt UNUSED,
-		struct page *page UNUSED) {
+		struct page *page UNUSED) 
+{
 	int succ = false;
 	/* TODO: Fill this function. */
 
@@ -124,38 +133,53 @@ spt_insert_page (struct supplemental_page_table *spt UNUSED,
 }
 
 void
-spt_remove_page (struct supplemental_page_table *spt, struct page *page) {
+spt_remove_page (struct supplemental_page_table *spt, struct page *page) 
+{
 	vm_dealloc_page (page);
+
+	/** TODO: page 해제
+	 * 매핑된 프레임을 해제해야하나?
+	 * 프레임이 스왑되어있는지 체크할것?
+	 * 아마 pml4_clear_page 사용하면 된대요
+	 */
+
 	return true;
 }
 
-/* Get the struct frame, that will be evicted. */
+/* 교체될 struct frame을 가져옵니다. */
 static struct frame *
-vm_get_victim (void) {
+vm_get_victim (void) 
+{
 	struct frame *victim = NULL;
-	 /* TODO: The policy for eviction is up to you. */
+	/* TODO: 교체 정책을 여기서 구현해서 희생자 페이지 찾기 */
 
 	return victim;
 }
 
-/* Evict one page and return the corresponding frame.
- * Return NULL on error.*/
+/* 한 페이지를 교체(evict)하고 해당 프레임을 반환합니다.
+ * 에러가 발생하면 NULL을 반환합니다.*/
 static struct frame *
-vm_evict_frame (void) {
+vm_evict_frame (void) 
+{
 	struct frame *victim UNUSED = vm_get_victim ();
 	/* TODO: swap out the victim and return the evicted frame. */
 
+	/* TODO: 여기서 swap_out 매크로를 호출??
+	 *	pml4_clear_page를 아마 사용?? (잘 모름)
+	 */
 	return NULL;
 }
 
-/* palloc() and get frame. If there is no available page, evict the page
- * and return it. This always return valid address. That is, if the user pool
- * memory is full, this function evicts the frame to get the available memory
- * space.*/
+/* palloc()을 사용하여 프레임을 할당합니다.
+ * 사용 가능한 페이지가 없으면 페이지를 교체(evict)하여 반환합니다.
+ * 이 함수는 항상 유효한 주소를 반환합니다. 즉, 사용자 풀 메모리가 가득 차면,
+ * 이 함수는 프레임을 교체하여 사용 가능한 메모리 공간을 확보합니다.*/
 static struct frame *
-vm_get_frame (void) {
+vm_get_frame(void)
+{
 	struct frame *frame = NULL;
 	/* TODO: Fill this function. */
+	/* 25.05.30 고재웅 작성 */
 
 	// 1. 유저 풀에서 새로운 페이지 할당
 	void *kva = palloc_get_page(PAL_USER);
@@ -178,25 +202,32 @@ vm_get_frame (void) {
 	// 4. 전역 frame_table에 프레임 등록
 	list_push_back(&frame_table, &frame->elem);
 
-	ASSERT (frame != NULL);
-	ASSERT (frame->page == NULL);
+	ASSERT(frame != NULL);
+	ASSERT(frame->page == NULL);
 	return frame;
 }
 
 /* Growing the stack. */
 static void
-vm_stack_growth (void *addr UNUSED) {
+vm_stack_growth(void *addr UNUSED)
+{
+	/* 25.05.30 정진영 작성
+	 * 스택 최하단에 익명 페이지를 추가하여 사용
+	 * addr은 PGSIZE로 내림(정렬)하여 사용 */
+	vm_alloc_page(VM_ANON, addr, true); // 스택 최하단에 익명 페이지 추가
 }
 
 /* Handle the fault on write_protected page */
 static bool
-vm_handle_wp (struct page *page UNUSED) {
+vm_handle_wp (struct page *page UNUSED) 
+{
 }
 
 /* Return true on success */
 bool
 vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
-		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
+		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) 
+{
 	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
 	struct page *page = NULL;
 	/* TODO: Validate the fault */
@@ -233,25 +264,29 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 /* Free the page.
  * DO NOT MODIFY THIS FUNCTION. */
 void
-vm_dealloc_page (struct page *page) {
+vm_dealloc_page (struct page *page) 
+{
 	destroy (page);
 	free (page);
 }
 
-/* Claim the page that allocate on VA. */
+/* VA에 할당된 페이지를 요구합니다 . */
 bool
-vm_claim_page (void *va UNUSED) {
+vm_claim_page (void *va UNUSED) 
+{
 	struct page *page = NULL;
 	/* TODO: Fill this function */
 
 	return vm_do_claim_page (page);
 }
 
-/* Claim the PAGE and set up the mmu. */
+/* PAGE를 요구하고 mmu를 설정합니다*/
 static bool
-vm_do_claim_page (struct page *page) {
+vm_do_claim_page (struct page *page) 
+{
 	struct frame *frame = vm_get_frame ();
-
+	/* TODO: vm_get_frame이 실패하면 swap_out */
+	
 	/* Set links */
 	frame->page = page;
 	page->frame = frame;
@@ -276,14 +311,16 @@ supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
 /* Copy supplemental page table from src to dst */
 bool
 supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
-		struct supplemental_page_table *src UNUSED) {
+		struct supplemental_page_table *src UNUSED) 
+{
 }
 
 /* Free the resource hold by the supplemental page table */
 void
-supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
-	/* TODO: Destroy all the supplemental_page_table hold by thread and
-	 * TODO: writeback all the modified contents to the storage. */
+supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) 
+{
+	/* TODO: 스레드가 보유한 모든 supplemental_page_table을 제거하고,
+	 * TODO: 수정된 내용을 스토리지에 기록(writeback)하세요. */
 }
 
 /* 25.05.30 고재웅 작성 */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -1,68 +1,77 @@
-/* vm.c: Generic interface for virtual memory objects. */
+/* vm.c: 
+ * 가상 메모리(Virtual Memory) 전반에 대한 인터페이스를 제공
+ * 
+ */
 
 #include "threads/malloc.h"
 #include "vm/vm.h"
 #include "vm/inspect.h"
+#include "threads/mmu.h"
 
-/* Initializes the virtual memory subsystem by invoking each subsystem's
- * intialize codes. */
-void
-vm_init (void) {
-	vm_anon_init ();
-	vm_file_init ();
-#ifdef EFILESYS  /* For project 4 */
-	pagecache_init ();
+/* 각 서브시스템의 초기화 코드를 호출하여 가상 메모리 서브시스템을 초기화합니다. */
+void 
+vm_init (void)
+{
+	vm_anon_init();
+	vm_file_init();
+#ifdef EFILESYS /* For project 4 */
+	pagecache_init();
 #endif
-	register_inspect_intr ();
-	/* DO NOT MODIFY UPPER LINES. */
-	/* TODO: Your code goes here. */
+	register_inspect_intr();
+	/* 이 위쪽은 수정하지 마세요 !! */
+	/* TODO: 이 아래쪽부터 코드를 추가하세요 */
 }
 
-/* Get the type of the page. This function is useful if you want to know the
- * type of the page after it will be initialized.
- * This function is fully implemented now. */
+/* 페이지의 타입을 가져옵니다. 이 함수는 페이지가 초기화된 후 타입을 알고 싶을 때 유용합니다.
+ * 이 함수는 이미 완전히 구현되어 있습니다. */
 enum vm_type
-page_get_type (struct page *page) {
-	int ty = VM_TYPE (page->operations->type);
-	switch (ty) {
-		case VM_UNINIT:
-			return VM_TYPE (page->uninit.type);
-		default:
-			return ty;
+page_get_type(struct page *page)
+{
+	int ty = VM_TYPE(page->operations->type);
+	switch (ty)
+	{
+	case VM_UNINIT:
+		return VM_TYPE(page->uninit.type);
+	default:
+		return ty;
 	}
 }
 
 /* Helpers */
-static struct frame *vm_get_victim (void);
-static bool vm_do_claim_page (struct page *page);
-static struct frame *vm_evict_frame (void);
+static struct frame *vm_get_victim(void);
+static bool vm_do_claim_page(struct page *page);
+static struct frame *vm_evict_frame(void);
 
-/* Create the pending page object with initializer. If you want to create a
- * page, do not create it directly and make it through this function or
- * `vm_alloc_page`. */
-bool
-vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
-		vm_initializer *init, void *aux) {
+/* 초기화 함수와 함께 대기 중인 페이지 객체를 생성합니다. 페이지를 직접 생성하지 말고,
+ * 반드시 이 함수나 `vm_alloc_page`를 통해 생성하세요. */
+bool 
+vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
+									vm_initializer *init, void *aux)
+{
 
-	ASSERT (VM_TYPE(type) != VM_UNINIT)
+	ASSERT(VM_TYPE(type) != VM_UNINIT)
 
-	struct supplemental_page_table *spt = &thread_current ()->spt;
+	struct supplemental_page_table *spt = &thread_current()->spt;
 
-	/* Check wheter the upage is already occupied or not. */
-	if (spt_find_page (spt, upage) == NULL) {
-		/* TODO: Create the page, fetch the initialier according to the VM type,
-		 * TODO: and then create "uninit" page struct by calling uninit_new. You
-		 * TODO: should modify the field after calling the uninit_new. */
+	/* 이미 해당 page가 SPT에 존재하는지 확인합니다 */
+	if (spt_find_page(spt, upage) == NULL)
+	{
+		/* TODO: VM 타입에 따라 페이지를 생성하고, 초기화 함수를 가져온 뒤,
+		 * TODO: uninit_new를 호출하여 "uninit" 페이지 구조체를 생성하세요.
+		 * TODO: uninit_new 호출 후에는 필요한 필드를 수정해야 합니다. */
 
-		/* TODO: Insert the page into the spt. */
+		/* TODO: 생성한 페이지를 spt에 삽입하세요. */
 	}
 err:
 	return false;
 }
 
 /* Find VA from spt and return page. On error, return NULL. */
+/* 가상 주소를 통해 SPT에서 페이지를 찾아 리턴합니다.
+ * 에러가 발생하면 NULL을 리턴하세요 */
 struct page *
-spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
+spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) 
+{
 	struct page *page = NULL;
 	/* TODO: Fill this function. */
 
@@ -72,7 +81,8 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 /* Insert PAGE into spt with validation. */
 bool
 spt_insert_page (struct supplemental_page_table *spt UNUSED,
-		struct page *page UNUSED) {
+		struct page *page UNUSED) 
+{
 	int succ = false;
 	/* TODO: Fill this function. */
 
@@ -80,58 +90,72 @@ spt_insert_page (struct supplemental_page_table *spt UNUSED,
 }
 
 void
-spt_remove_page (struct supplemental_page_table *spt, struct page *page) {
+spt_remove_page (struct supplemental_page_table *spt, struct page *page) 
+{
 	vm_dealloc_page (page);
 	return true;
 }
 
 /* Get the struct frame, that will be evicted. */
 static struct frame *
-vm_get_victim (void) {
+vm_get_victim (void) 
+{
 	struct frame *victim = NULL;
-	 /* TODO: The policy for eviction is up to you. */
+	/* TODO: 교체 정책을 여기서 구현해서 희생자 페이지 찾기 */
 
 	return victim;
 }
 
-/* Evict one page and return the corresponding frame.
- * Return NULL on error.*/
+/* 한 페이지를 교체(evict)하고 해당 프레임을 반환합니다.
+ * 에러가 발생하면 NULL을 반환합니다.*/
 static struct frame *
-vm_evict_frame (void) {
+vm_evict_frame (void) 
+{
 	struct frame *victim UNUSED = vm_get_victim ();
 	/* TODO: swap out the victim and return the evicted frame. */
 
 	return NULL;
 }
 
-/* palloc() and get frame. If there is no available page, evict the page
- * and return it. This always return valid address. That is, if the user pool
- * memory is full, this function evicts the frame to get the available memory
- * space.*/
+/* palloc()을 사용하여 프레임을 할당합니다.
+ * 사용 가능한 페이지가 없으면 페이지를 교체(evict)하여 반환합니다.
+ * 이 함수는 항상 유효한 주소를 반환합니다. 즉, 사용자 풀 메모리가 가득 차면,
+ * 이 함수는 프레임을 교체하여 사용 가능한 메모리 공간을 확보합니다.*/
 static struct frame *
-vm_get_frame (void) {
+vm_get_frame(void)
+{
 	struct frame *frame = NULL;
 	/* TODO: Fill this function. */
+	/**
+	 * 여기서 swap_out을 진행해야 합니다
+	 * pml4_clear_page를 사용해서 물리 주소를 클리어 합니다
+	 */
 
-	ASSERT (frame != NULL);
-	ASSERT (frame->page == NULL);
+	ASSERT(frame != NULL);
+	ASSERT(frame->page == NULL);
 	return frame;
 }
 
 /* Growing the stack. */
 static void
-vm_stack_growth (void *addr UNUSED) {
+vm_stack_growth(void *addr UNUSED)
+{
+	/* 스택 최하단에 익명 페이지를 추가하여 사용
+	 * addr은 PGSIZE로 내림(정렬)하여 사용	 */
+	vm_alloc_page(VM_ANON, addr, true); // 스택 최하단에 익명 페이지 추가
 }
 
 /* Handle the fault on write_protected page */
 static bool
-vm_handle_wp (struct page *page UNUSED) {
+vm_handle_wp (struct page *page UNUSED) 
+{
 }
 
 /* Return true on success */
 bool
 vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
-		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) {
+		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) 
+{
 	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
 	struct page *page = NULL;
 	/* TODO: Validate the fault */
@@ -143,23 +167,26 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 /* Free the page.
  * DO NOT MODIFY THIS FUNCTION. */
 void
-vm_dealloc_page (struct page *page) {
+vm_dealloc_page (struct page *page) 
+{
 	destroy (page);
 	free (page);
 }
 
-/* Claim the page that allocate on VA. */
+/* VA에 할당된 페이지를 요구합니다 . */
 bool
-vm_claim_page (void *va UNUSED) {
+vm_claim_page (void *va UNUSED) 
+{
 	struct page *page = NULL;
 	/* TODO: Fill this function */
 
 	return vm_do_claim_page (page);
 }
 
-/* Claim the PAGE and set up the mmu. */
+/* PAGE를 요구하고 mmu를 설정합니다*/
 static bool
-vm_do_claim_page (struct page *page) {
+vm_do_claim_page (struct page *page) 
+{
 	struct frame *frame = vm_get_frame ();
 
 	/* Set links */
@@ -173,18 +200,21 @@ vm_do_claim_page (struct page *page) {
 
 /* Initialize new supplemental page table */
 void
-supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
+supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) 
+{
 }
 
 /* Copy supplemental page table from src to dst */
 bool
 supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
-		struct supplemental_page_table *src UNUSED) {
+		struct supplemental_page_table *src UNUSED) 
+{
 }
 
 /* Free the resource hold by the supplemental page table */
 void
-supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
-	/* TODO: Destroy all the supplemental_page_table hold by thread and
-	 * TODO: writeback all the modified contents to the storage. */
+supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) 
+{
+	/* TODO: 스레드가 보유한 모든 supplemental_page_table을 제거하고,
+	 * TODO: 수정된 내용을 스토리지에 기록(writeback)하세요. */
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -95,13 +95,13 @@ err:
 	return false;
 }
 
-/* Find VA from spt and return page. On error, return NULL. */
-/* 가상 주소를 통해 SPT에서 페이지를 찾아 리턴합니다.
+/* va → struct page *를 찾는 함수
+ * 가상 주소를 통해 SPT에서 페이지를 찾아 리턴합니다.
  * 에러가 발생하면 NULL을 리턴하세요. */
 struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	struct page *page = NULL;
-	/* TODO: Fill this function. */
+
 	/* 25.05.30 고재웅 작성 */
 	struct page temp;
 	temp.va = pg_round_down(va);
@@ -111,25 +111,14 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 	return hash_entry(e, struct page, hash_elem);
 }
 
-/* PAGE를 spt에 삽입하며 검증을 수행합니다. */
+/* 주어진 PAGE를 spt에 삽입하며 검증을 수행합니다. 
+ * 이미 해당 가상 주소가 등록되어 있다면 실패 처리해야 합니다. */
 bool
-spt_insert_page (struct supplemental_page_table *spt UNUSED,
-		struct page *page UNUSED) 
+spt_insert_page (struct supplemental_page_table *spt UNUSED, struct page *page UNUSED) 
 {
-	int succ = false;
-	/* TODO: Fill this function. */
-
-	/* 25.05.30 고재웅 작성 */
-	// 먼저 페이지 테이블에서 가상 주소가 존재하지 않는지 검사한다.
-	struct hash_elem *prev_elem = hash_find(&spt->pages, &page->hash_elem);
-	if (prev_elem == NULL){
-	  	// 페이지 테이블에 페이지 구조체를 삽입한다.
-		if (hash_insert(&spt->pages, &page->hash_elem)){
-			succ = true;
-			return succ;
-		}
-	}
-	return succ;
+	/* 25.05.30 정진영 작성 */
+	/* hash_insert는 중복 키가 존재하면 기존 요소를 반환하고, 성공적으로 삽입되면 NULL을 반환한다. */
+	return hash_insert(&spt->pages, &page->hash_elem) == NULL;
 }
 
 void
@@ -302,34 +291,21 @@ vm_do_claim_page (struct page *page)
 
 /* Initialize new supplemental page table */
 /* 25.05.30 고재웅 작성 */
+
+/* 프로세스가 시작될 때(initd) or 포크될 때(__do_fork) 호출되는 함수 */
 void
-supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
+supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) 
+{
 	/* SPT 초기화시 hash_init에 아래 작성한 page_hash, page_less를 포함한다. */
 	hash_init(&spt->pages, page_hash, page_less, NULL);
 }
 
-/* Copy supplemental page table from src to dst */
-bool
-supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
-		struct supplemental_page_table *src UNUSED) 
-{
-}
-
-/* Free the resource hold by the supplemental page table */
-void
-supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) 
-{
-	/* TODO: 스레드가 보유한 모든 supplemental_page_table을 제거하고,
-	 * TODO: 수정된 내용을 스토리지에 기록(writeback)하세요. */
-}
-
-/* 25.05.30 고재웅 작성 */
 /* SPT 해시 테이블에 넣기 위한 hash_func & less_func 함수 구현 */
 
 /* page_hash 가상 주소를 바탕으로 해시값을 계산한다. */
 uint64_t page_hash(const struct hash_elem *e, void *aux){
 	struct page *p = hash_entry(e, struct page, hash_elem);
-	return hash_bytes(&p, sizeof(p->va));
+	return hash_bytes(&p->va, sizeof(p->va));
 }
 
 /* 두 page의 va를 기준으로 정렬을 비교한다. */
@@ -338,4 +314,45 @@ bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux){
 	struct page *pa = hash_entry(a, struct page, hash_elem);
 	struct page *pb = hash_entry(b, struct page, hash_elem);
 	return pa->va < pb->va;
+}
+
+/* 주로 fork() 혹은 __do_fork() 시, 자식도 부모처럼 똑같은 주소 공간을 갖기 위해 SPT를 복사
+ * hash_first(), hash_next()를 써서 src의 모든 페이지를 순회하면서 dst에 복사해야 합니다. */
+bool
+supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
+		struct supplemental_page_table *src UNUSED) 
+{
+	/* 	🟪 TODO 
+	복사 시:
+	•	page_get_type()으로 타입 확인
+	•	vm_alloc_page_with_initializer()로 새 페이지 생성
+	•	claim_page() 후 실제 물리 메모리 복사 
+
+	단순 복사는 struct page만 (init 정보), 내용 복사는 struct page + 메모리의 내용 (frame or swap) 까지
+	내용 복사 하려면 frame 할당이랑 memcpy 필요함
+
+	- uninit lazy page: 아직 실제 데이터가 로딩되지 않음 -> 단순 복사 (init 정보만 복사)
+	- frame이 있는 페이지: 이미 메모리에 올라감 -> 실제 메모리 내용도 복사해야 함
+	- 스왑된 페이지: 디스크에만 있음 -> 복원 후 복사하거나 스왑 슬롯 공유 고려
+
+	page->frame == NULL이면 실제로 메모리에 올라오지 않음. 
+	즉, 아직 page fault가 발생하지 않은 lazy-load 페이지
+	혹은 swap-out 되어 메모리에는 없는 페이지
+	이런 경우는 데이터 복사 불필요 -> vm_alloc_page_with_initializer()로 초기 정보만 복사해서 동일한 lazy loading 조건을 만들면 됨!!!
+	*/
+}
+
+/* Free the resource hold by the supplemental page table */
+void
+supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) 
+{
+	/* TODO: 스레드가 보유한 모든 supplemental_page_table을 제거하고,
+	 * TODO: 수정된 내용을 스토리지에 기록(writeback)하세요. */
+
+	/* 	🟪 TODO 
+	hash_destroy() 사용
+	•	각 페이지에 대해 destroy(page) 호출해서:
+	•	swap out 필요 시 writeback
+	•	프레임 반환
+	•	구조체 메모리 해제 */
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -8,6 +8,10 @@
 #include "vm/inspect.h"
 #include "threads/mmu.h"
 
+/* 25.05.30 고재웅 작성 */
+#include <hash.h>
+#include "threads/vaddr.h"
+
 /* 각 서브시스템의 초기화 코드를 호출하여 가상 메모리 서브시스템을 초기화합니다. */
 void 
 vm_init (void)
@@ -53,13 +57,36 @@ vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
 
 	struct supplemental_page_table *spt = &thread_current()->spt;
 
-	/* 이미 해당 page가 SPT에 존재하는지 확인합니다 */
+	/* 이미 해당 page가 SPT에 존재하는지 확인합니다. */
 	if (spt_find_page(spt, upage) == NULL)
 	{
 		/* TODO: VM 타입에 따라 페이지를 생성하고, 초기화 함수를 가져온 뒤,
 		 * TODO: uninit_new를 호출하여 "uninit" 페이지 구조체를 생성하세요.
 		 * TODO: uninit_new 호출 후에는 필요한 필드를 수정해야 합니다. */
 
+		// /* 25.05.30 정진영 작성 */ 
+		// bool (*page_initializer)(struct page *, enum vm_type, void *kva);
+		// struct page *page = malloc(sizeof(struct page));
+		// page->writable = writable;
+
+		// switch (VM_TYPE(type))
+		// {
+		// case VM_ANON:
+		// 	page_initializer = anon_initializer;
+		// 	break;
+		// case VM_MMAP:
+		// 	/* 매핑 카운트를 추가해두자
+		// 	   mmap_list로 mmap 페이지를 관리할거면 필요 x */
+		// case VM_FILE:
+		// 	page_initializer = file_backed_initializer;
+		// 	break;
+		// default:
+		// 	free(page);
+		// 	goto err;
+		// 	break;
+		// }
+
+		uninit_new(page, upage, init, type, aux, page_initializer);
 		/* TODO: 생성한 페이지를 spt에 삽입하세요. */
 	}
 err:
@@ -68,17 +95,26 @@ err:
 
 /* Find VA from spt and return page. On error, return NULL. */
 /* 가상 주소를 통해 SPT에서 페이지를 찾아 리턴합니다.
- * 에러가 발생하면 NULL을 리턴하세요 */
+ * 에러가 발생하면 NULL을 리턴하세요. */
 struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) 
 {
 	struct page *page = NULL;
 	/* TODO: Fill this function. */
 
-	return page;
+	/* 25.05.30 고재웅 작성 */
+	page.va = pg_round_down(va);
+	// 보조 테이블에서 va가 포함된 구조체를 찾는다.
+  	struct hash_elem *find_elem = hash_find(&spt->pages, page->hash_elem);
+	// 찾지 못했다면 NULL 반환
+	if (find_elem == NULL){
+		return NULL;
+	}
+	// 구조체를 찾으면 구조체를 반환
+	return hash_entry(find_elem, struct page, hash_elem);
 }
 
-/* Insert PAGE into spt with validation. */
+/* PAGE를 spt에 삽입하며 검증을 수행합니다. */
 bool
 spt_insert_page (struct supplemental_page_table *spt UNUSED,
 		struct page *page UNUSED) 
@@ -86,6 +122,16 @@ spt_insert_page (struct supplemental_page_table *spt UNUSED,
 	int succ = false;
 	/* TODO: Fill this function. */
 
+	/* 25.05.30 고재웅 작성 */
+	// 먼저 페이지 테이블에서 가상 주소가 존재하지 않는지 검사한다.
+	struct hash_elem *prev_elem = hash_find(&spt->pages, &page->hash_elem);
+	if (prev_elem == NULL){
+	  	// 페이지 테이블에 페이지 구조체를 삽입한다.
+		if (hash_insert(&spt->pages, &page->hash_elem)){
+			succ = true;
+			return succ;
+		}
+	}
 	return succ;
 }
 
@@ -93,10 +139,17 @@ void
 spt_remove_page (struct supplemental_page_table *spt, struct page *page) 
 {
 	vm_dealloc_page (page);
+
+	/** TODO: page 해제
+	 * 매핑된 프레임을 해제해야하나?
+	 * 프레임이 스왑되어있는지 체크할것?
+	 * 아마 pml4_clear_page 사용하면 된대요
+	 */
+
 	return true;
 }
 
-/* Get the struct frame, that will be evicted. */
+/* 교체될 struct frame을 가져옵니다. */
 static struct frame *
 vm_get_victim (void) 
 {
@@ -114,6 +167,9 @@ vm_evict_frame (void)
 	struct frame *victim UNUSED = vm_get_victim ();
 	/* TODO: swap out the victim and return the evicted frame. */
 
+	/* TODO: 여기서 swap_out 매크로를 호출??
+	 *	pml4_clear_page를 아마 사용?? (잘 모름)
+	 */
 	return NULL;
 }
 
@@ -126,9 +182,9 @@ vm_get_frame(void)
 {
 	struct frame *frame = NULL;
 	/* TODO: Fill this function. */
-	/**
-	 * 여기서 swap_out을 진행해야 합니다
-	 * pml4_clear_page를 사용해서 물리 주소를 클리어 합니다
+	/*
+	 * 여기서 swap_out을 진행해야 합니다.
+	 * pml4_clear_page를 사용해서 물리 주소를 클리어 합니다.
 	 */
 
 	ASSERT(frame != NULL);
@@ -140,8 +196,9 @@ vm_get_frame(void)
 static void
 vm_stack_growth(void *addr UNUSED)
 {
-	/* 스택 최하단에 익명 페이지를 추가하여 사용
-	 * addr은 PGSIZE로 내림(정렬)하여 사용	 */
+	/* 25.05.30 정진영 작성
+	 * 스택 최하단에 익명 페이지를 추가하여 사용
+	 * addr은 PGSIZE로 내림(정렬)하여 사용 */
 	vm_alloc_page(VM_ANON, addr, true); // 스택 최하단에 익명 페이지 추가
 }
 
@@ -188,7 +245,8 @@ static bool
 vm_do_claim_page (struct page *page) 
 {
 	struct frame *frame = vm_get_frame ();
-
+	/* TODO: vm_get_frame이 실패하면 swap_out */
+	
 	/* Set links */
 	frame->page = page;
 	page->frame = frame;
@@ -199,9 +257,9 @@ vm_do_claim_page (struct page *page)
 }
 
 /* Initialize new supplemental page table */
+/* 25.05.30 고재웅 작성 */
 void
-supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) 
-{
+supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) {
 }
 
 /* Copy supplemental page table from src to dst */
@@ -217,4 +275,21 @@ supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED)
 {
 	/* TODO: 스레드가 보유한 모든 supplemental_page_table을 제거하고,
 	 * TODO: 수정된 내용을 스토리지에 기록(writeback)하세요. */
+}
+
+/* 25.05.30 고재웅 작성 */
+/* SPT 해시 테이블에 넣기 위한 hash_func & less_func 함수 구현 */
+
+/* page_hash 가상 주소를 바탕으로 해시값을 계산한다. */
+uint64_t page_hash(onst struct hash_elem *e, void *aux){
+	struct page *p = hash_entry(e, struct page, hash_elem);
+	return hash_bytes(&p, sizeof(p->va));
+}
+
+/* 두 page의 va를 기준으로 정렬을 비교한다. */
+bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux){
+	/* 이 함수는 해시 테이블 충돌 시 내부 정렬에 사용된다고 한다. */
+	struct page *pa = hash_entry(a, struct page, hash_elem);
+	struct page *pb = hash_entry(b, struct page, hesh_elem);
+	return pa->va < pb->va;
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -11,6 +11,7 @@
  * intialize codes. */
 void
 vm_init (void) {
+	list_init(&frame_table);
 	vm_anon_init ();
 	vm_file_init ();
 #ifdef EFILESYS  /* For project 4 */
@@ -50,35 +51,56 @@ vm_alloc_page_with_initializer (enum vm_type type, void *upage, bool writable,
 	ASSERT (VM_TYPE(type) != VM_UNINIT)
 
 	struct supplemental_page_table *spt = &thread_current ()->spt;
-
+	struct page *page = NULL;
 	/* Check wheter the upage is already occupied or not. */
 	if (spt_find_page (spt, upage) == NULL) {
-		/* TODO: Create the page, fetch the initialier according to the VM type,
-		 * TODO: and then create "uninit" page struct by calling uninit_new. You
-		 * TODO: should modify the field after calling the uninit_new. */
+		/* TODO: 페이지를 생성하고, VM 유형에 따라 초기화 파일을 가져옵니다.
+		* TODO: 그런 다음 uninit_new를 호출하여 "uninit" 페이지 구조체를 생성합니다.
+		* TODO: uninit_new를 호출한 후 필드를 수정해야 합니다. */
+		page = malloc(sizeof(struct page));
+		if (page == NULL){
+			return false;
+		}
+		bool (*page_initializer) (struct page *, enum vm_type, void *kva) = NULL;
 
-		/* TODO: Insert the page into the spt. */
+		switch (VM_TYPE(type))
+		{
+			case VM_ANON:
+				page_initializer = anon_initializer;
+				break;
+			case VM_FILE:
+				page_initializer = file_backed_initializer;
+				break;
+			default:
+				goto err;
+		}
+		/* TODO: spt에 페이지를 삽입합니다. */
+		uninit_new(page, upage, init, type, aux, page_initializer);
+
+		page->writable = writable;
+
+		if (!spt_insert_page(spt, page)){
+			return true;
+		}
 	}
+	else
+		return false;
 err:
+	free(page);
 	return false;
 }
 
 /* Find VA from spt and return page. On error, return NULL. */
 struct page *
 spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-	struct page *page = NULL;
 	/* TODO: Fill this function. */
-
 	/* 25.05.30 고재웅 작성 */
-	page.va = pg_round_down(va);
-	// 보조 테이블에서 va가 포함된 구조체를 찾는다.
-  	struct hash_elem *find_elem = hash_find(&spt->pages, page->hash_elem);
-	// 찾지 못했다면 NULL 반환
-	if (find_elem == NULL){
+	struct page temp;
+	temp.va = pg_round_down(va);
+	struct hash_elem *e = hash_find(&spt->pages, &temp.hash_elem);
+	if (e == NULL)
 		return NULL;
-	}
-	// 구조체를 찾으면 구조체를 반환
-	return hash_entry(find_elem, struct page, hash_elem);
+	return hash_entry(e, struct page, hash_elem);
 }
 
 /* Insert PAGE into spt with validation. */
@@ -135,6 +157,27 @@ vm_get_frame (void) {
 	struct frame *frame = NULL;
 	/* TODO: Fill this function. */
 
+	// 1. 유저 풀에서 새로운 페이지 할당
+	void *kva = palloc_get_page(PAL_USER);
+
+	// 2. 할당 실패 시 PANIC
+	if (kva == NULL) {
+		PANIC("todo: implement eviction here");
+	}
+
+	// 3. 프레임 구조체 할당 및 초기화
+	frame = malloc(sizeof(struct frame));
+	if (frame == NULL) {
+		PANIC("frame allocation failed");
+	}
+
+	frame->kva = kva;
+	frame->page = NULL;  // 아직 연결된 페이지 없음
+	frame->owner = thread_current();  // 현재 스레드를 소유자로 설정
+
+	// 4. 전역 frame_table에 프레임 등록
+	list_push_back(&frame_table, &frame->elem);
+
 	ASSERT (frame != NULL);
 	ASSERT (frame->page == NULL);
 	return frame;
@@ -158,6 +201,31 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 	struct page *page = NULL;
 	/* TODO: Validate the fault */
 	/* TODO: Your code goes here */
+	// 1. 주소 유효성 검사
+	if (addr == NULL || is_kernel_vaddr(addr)) {
+		return false;
+	}
+
+	// 2. 접근 권한 검사
+	if (!not_present) {
+		// 존재하는 페이지에 대해 쓰기 금지 등
+		return false;
+	}
+
+	// 3. 주소를 페이지 기준으로 내림 (page alignment)
+	void *page_va = pg_round_down(addr);
+
+	// 4. 보조 페이지 테이블에서 해당 페이지 찾기
+	page = spt_find_page(spt, page_va);
+	if (page == NULL) {
+		// 스택 확장을 고려해 여기서 vm_stack_growth 등을 호출할 수도 있음
+		return false;
+	}
+
+	// 5. 쓰기 접근인데 읽기 전용 페이지면 오류
+	if (write && !page->writable) {
+		return false;
+	}
 
 	return vm_do_claim_page (page);
 }
@@ -189,6 +257,10 @@ vm_do_claim_page (struct page *page) {
 	page->frame = frame;
 
 	/* TODO: Insert page table entry to map page's VA to frame's PA. */
+	/* 페이지의 VA와 프레임의 KVA를 페이지 테이블에 매핑 */
+	if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable)) {
+		return false;
+	}
 
 	return swap_in (page, frame->kva);
 }
@@ -218,7 +290,7 @@ supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) {
 /* SPT 해시 테이블에 넣기 위한 hash_func & less_func 함수 구현 */
 
 /* page_hash 가상 주소를 바탕으로 해시값을 계산한다. */
-uint64_t page_hash(onst struct hash_elem *e, void *aux){
+uint64_t page_hash(const struct hash_elem *e, void *aux){
 	struct page *p = hash_entry(e, struct page, hash_elem);
 	return hash_bytes(&p, sizeof(p->va));
 }
@@ -227,6 +299,6 @@ uint64_t page_hash(onst struct hash_elem *e, void *aux){
 bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux){
 	/* 이 함수는 해시 테이블 충돌 시 내부 정렬에 사용된다고 한다. */
 	struct page *pa = hash_entry(a, struct page, hash_elem);
-	struct page *pb = hash_entry(b, struct page, hesh_elem);
+	struct page *pb = hash_entry(b, struct page, hash_elem);
 	return pa->va < pb->va;
 }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -48,7 +48,6 @@ static bool vm_do_claim_page(struct page *page);
 static struct frame *vm_evict_frame(void);
 
 /* 25.06.01 고재웅 작성
- * 25.06.02 정진영 수정 (주석 추가, 페이지 구조체 할당 실패 처리, switch 문 default 추가)
  * 초기화 함수와 함께 대기 중인 페이지 객체를 생성한다. 페이지를 직접 생성하지 말고,
  * 반드시 이 함수나 `vm_alloc_page`를 통해 생성하라. 
  * 페이지를 할당하고 타입을 uninit으로 설정한다.
@@ -57,24 +56,19 @@ bool
 vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
 									vm_initializer *init, void *aux)
 {
-	// 1. UNINIT이 아닌 실제 타입만 이 함수로 생성 가능 (VM_ANON, VM_FILE 등)
+
 	ASSERT(VM_TYPE(type) != VM_UNINIT)
 
-	// 2. 현재 스레드의 spt 획득
 	struct supplemental_page_table *spt = &thread_current ()->spt;
 
-	// 3. 이미 해당 가상 주소(upage)에 페이지가 존재한다면 중복 삽입 방지
+	/* Check wheter the upage is already occupied or not. */
 	if (spt_find_page (spt, upage) == NULL) {
 		/* TODO: 페이지를 생성하고, VM 유형에 따라 초기화 파일을 가져옵니다.Add commentMore actions
 		 * TODO: 그런 다음 uninit_new를 호출하여 "uninit" 페이지 구조체를 생성합니다.
 		 * TODO: uninit_new를 호출한 후 필드를 수정해야 합니다. */
-
-		// 4. 새로운 page 구조체 동적 할당
 		struct page *p = (struct page *)malloc(sizeof(struct page));
-		if (p == NULL) return false;
-
-		// 5. 유형별 초기화 함수 선택 (UNINIT → 실제 타입으로 변환될 때 호출됨)
 		bool (*page_initializer)(struct page *, enum vm_type, void *);
+
 		switch (VM_TYPE(type))
 		{
 			case VM_ANON:
@@ -83,14 +77,11 @@ vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
 			case VM_FILE:
 				page_initializer = file_backed_initializer;
 				break;
-			default:
-    			PANIC("Invalid VM type in vm_alloc_page_with_initializer");
 		}
-		// 6. uninit_new: lazy-loading용 uninit 페이지를 구성 & 쓰기 가능 여부 설정
+		/* TODO: spt에 페이지를 삽입합니다. */
 		uninit_new(p, upage, init, type, aux, page_initializer);
 		p->writable = writable;
 
-		// 7. spt에 페이지 등록
 		return spt_insert_page(spt, p);
 	}
 err:
@@ -122,8 +113,7 @@ bool
 spt_insert_page (struct supplemental_page_table *spt UNUSED, struct page *page UNUSED) 
 {
 	/* TODO: Fill this function. */
-	// return hash_insert(&spt->pages, &page->hash_elem) == NULL ? true : false;
-	return hash_insert(&spt->pages, &page->hash_elem) == NULL;
+	return hash_insert(&spt->pages, &page->hash_elem) == NULL ? true : false;
 }
 
 void
@@ -180,11 +170,8 @@ vm_get_frame(void)
 
 	// 2. 할당 실패 시 PANIC
 	if (kva == NULL) {
-		/* 추후 페이지 교체를 추가해야 한다.  
-		 * OS를 중지시키고, 소스 파일명, 라인 번호, 함수명 등의 정보와 함께 사용자 지정 메시지를 출력 
-		 * e.g. try_to_evict_and_allocate()
-		 */
-		PANIC("todo: implement eviction here");	
+		// 추후 페이지 교체를 추가해야 한다.
+		PANIC("todo: implement eviction here");
 	}
 
 	// 3. 프레임 구조체 할당 및 초기화
@@ -214,12 +201,14 @@ vm_handle_wp (struct page *page UNUSED)
 }
 
 /* 25.06.01 고재웅 작성 */
-/* 
- * 페이지 폴트 핸들러 함수
- * - not_present == true: 물리 프레임이 없어서 발생한 예외
- *   → 새로운 프레임을 할당해서 해결 가능 (vm_do_claim_page 호출)
- * - not_present == false: 페이지는 있지만 권한 문제 등으로 예외 발생
- *   → read-only 페이지에 write 시도 등 → 실패 처리
+/* Return true on success 
+ * 페이지 폴트 핸들러 - 페이지 폴트 발생시 제어권을 전달 받는다.
+ * 물리 프레임이 존재하지 않아서 발생한 예외는 not_present 가 true다
+ * 그 경우 물리 프레임 할당을 요청하는 vm_do_claim_page를 호출한다.
+ * 반대로 not_present 가 false인 경우는 물리 프레임이 할당되어 있지만 폴트가 발생한 것이다.
+ * read-only page에 write를 한경우 등 이 때에는 예외 처리를 하면 된다.
+ * 그렇다고 해서 not_present가 true인 경우에서 read-only page에 요청을 할 수 있으니 이에
+ * 대한 예외를 처리하라
  */
 bool
 vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
@@ -227,29 +216,25 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 {
 	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
 	struct page *page = NULL;
-	
-	// 1. 예외 주소 유효성 검사
-	if (addr == NULL)			// NULL 포인터 접근
+	/* TODO: Validate the fault */
+	/* TODO: Your code goes here */
+	// 1. 주소 유효성 검사
+	if (addr == NULL)
 		return false;
 
-	if (is_kernel_vaddr(addr))	// 커널 주소 접근은 유저 코드에서 금지
+	if (is_kernel_vaddr(addr))
 		return false;
 
-	// 2. 물리 프레임이 없는 경우 → lazy page 등 처리 가능
-	if (not_present) {
-        // 2-1. spt에서 해당 주소의 페이지 정보 검색
+	if (not_present) // 접근한 메모리의 physical page가 존재하지 않은 경우
+    {
+        /* TODO: Validate the fault */
         page = spt_find_page(spt, addr);
         if (page == NULL)
-            return false;		// 페이지 정보가 없다면 처리 불가
-
-		// 2-2. 쓰기 요청인데 쓰기 불가능한 페이지인 경우 → 예외
-        if (write == 1 && page->writable == 0) 
             return false;
-		
-		// 2-3. 페이지를 실체화하여 매핑 시도
+        if (write == 1 && page->writable == 0) // write 불가능한 페이지에 write 요청한 경우
+            return false;
         return vm_do_claim_page(page);
     }
-	// 3. 페이지는 있지만 권한 문제 등 → 실패 처리
     return false;
 }
 
@@ -263,11 +248,10 @@ vm_dealloc_page (struct page *page)
 }
 
 /* 25.06.01 고재웅 수정
-
  * VA에 해당하는 페이지를 가져온다. 
  * 해당 페이지로 vm_do_claim_page를 호출한다. */
 bool
-vm_claim_page (void *va) 
+vm_claim_page (void *va UNUSED) 
 {
 	/* TODO: Fill this function */
 	struct page *page = NULL;
@@ -279,7 +263,6 @@ vm_claim_page (void *va)
 }
 
 /* 25.06.01 고재웅 수정
- * 25.06.02 정진영 수정 (실패 처리 추가)
  * 인자로 주어진 page에 frame을 할당 한다. --> vm_get_frame()
  * mmu를 설정한다.(pml4) */
 static bool
@@ -287,8 +270,6 @@ vm_do_claim_page (struct page *page)
 {
 	struct frame *frame = vm_get_frame ();
 	/* TODO: vm_get_frame이 실패하면 swap_out */
-	if (frame == NULL)
-		PANIC("Failed to allocate frame (eviction not yet implemented)"); // or return false;
 	
 	/* Set links */
 	frame->page = page;
@@ -297,16 +278,13 @@ vm_do_claim_page (struct page *page)
 	/* TODO: Insert page table entry to map page's VA to frame's PA. */
 	/* 페이지의 VA와 프레임의 KVA를 페이지 테이블에 매핑 */
 	struct thread *current = thread_current();
-    bool success = pml4_set_page(current->pml4, page->va, frame->kva, page->writable);
-	if (!success)
-	PANIC("pml4_set_page failed: possible double mapping or invalid VA");
+    pml4_set_page(current->pml4, page->va, frame->kva, page->writable);
 
 	return swap_in(page, frame->kva);
 }
 
 /* Initialize new supplemental page table */
-/* 25.05.30 고재웅 작성
- * 25.06.02 정진영 수정 (주석 추가) */
+/* 25.05.30 고재웅 작성 */
 
 /* 프로세스가 시작될 때(initd) or 포크될 때(__do_fork) 호출되는 함수 */
 void
@@ -319,62 +297,50 @@ supplemental_page_table_init (struct supplemental_page_table *spt UNUSED)
 /* Copy supplemental page table from src to dst */
 bool
 supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
-								struct supplemental_page_table *src UNUSED) 
+		struct supplemental_page_table *src UNUSED) 
 {
-	// src SPT를 순회할 hash iterator 준비
 	struct hash_iterator i;
 	hash_first(&i, &src->pages);
-
-	// src의 모든 page를 순회
-	while (hash_next(&i)) { 
-		// 현재 해시 엔트리에서 page 구조체 추출
+	while (hash_next(&i))
+	{
+		// src_page 정보
 		struct page *src_page = hash_entry(hash_cur(&i), struct page, hash_elem);
-
-		// src page 정보 복사
 		enum vm_type type = src_page->operations->type;
 		void *upage = src_page->va;
 		bool writable = src_page->writable;
 
-		/* 1) uninit type */
-		if (type == VM_UNINIT) { 
-			// 초기화 정보(지연 로딩 함수, aux 데이터) 복사	
+		/* 1) type이 uninit이면 */
+		if (type == VM_UNINIT)
+		{ // uninit page 생성 & 초기화
 			vm_initializer *init = src_page->uninit.init;
 			void *aux = src_page->uninit.aux;
-
-			// dst SPT에 UNINIT page 등록
-			if (!vm_alloc_page_with_initializer(type, upage, writable, init, aux))
-				goto err;
+			vm_alloc_page_with_initializer(VM_ANON, upage, writable, init, aux);
 			continue;
 		}
 
-		/* 2) Not uninit type */
-		// 새로 초기화 페이지 등록 (init은 NULL, 즉 lazy load 아님)
-		if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, NULL))
+		/* 2) type이 uninit이 아니면 */
+		if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, NULL)) // uninit page 생성 & 초기화
 			// init(lazy_load_segment)는 page_fault가 발생할때 호출됨
 			// 지금 만드는 페이지는 page_fault가 일어날 때까지 기다리지 않고 바로 내용을 넣어줘야 하므로 필요 없음
 			return false;
 
-		// 페이지를 바로 매핑 및 프레임 할당 (실제 물리 메모리 확보)
+		// vm_claim_page으로 요청해서 매핑 & 페이지 타입에 맞게 초기화
 		if (!vm_claim_page(upage))
 			return false;
 
-		struct page *dst_page = spt_find_page(dst, upage);			// dst의 페이지 구조체 가져옴
-		memcpy(dst_page->frame->kva, src_page->frame->kva, PGSIZE);	// src 프레임 데이터를 dst 프레임으로 복사
+		// 매핑된 프레임에 내용 로딩
+		struct page *dst_page = spt_find_page(dst, upage);
+		memcpy(dst_page->frame->kva, src_page->frame->kva, PGSIZE);
 	}
 	return true;
-
-err:
-	supplemental_page_table_kill(dst); // cleanup
-	return false;
 }
 
 /* Free the resource hold by the supplemental page table */
 void
 supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) 
 {
-	// 해시 테이블의 모든 페이지 구조체를 순회하며 spt 제거
-	// 각 엔트리는 hash_page_destroy() 함수에 의해 해제됨
-	// 수정된 내용을 스토리지에 기록(writeback)
+	/* TODO: 스레드가 보유한 모든 supplemental_page_table을 제거하고,
+	 * TODO: 수정된 내용을 스토리지에 기록(writeback)하세요. */
 	hash_clear(&spt->pages, hash_page_destroy);
 }
 
@@ -390,8 +356,7 @@ uint64_t page_hash(const struct hash_elem *e, void *aux){
 /* 두 page의 va를 기준으로 정렬을 비교한다. */
 bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux){
 	/* 이 함수는 해시 테이블 충돌 시 내부 정렬에 사용된다고 한다. */
-	struct page *pa = hash_entry
-	(a, struct page, hash_elem);
+	struct page *pa = hash_entry(a, struct page, hash_elem);
 	struct page *pb = hash_entry(b, struct page, hash_elem);
 	return pa->va < pb->va;
 }
@@ -402,20 +367,3 @@ void hash_page_destroy(struct hash_elem *e, void *aux)
 	destroy(page);
 	free(page);
 }
-
-// void hash_page_destroy(struct hash_elem *e, void *aux)
-// {
-// 	struct page *page = hash_entry(e, struct page, hash_elem);
-// 	// destroy(page);
-
-// 	// destroy 함수 등록되어 있다면 호출
-// 	if (page->operations && page->operations->destroy)
-// 	page->operations->destroy(page);
-
-// 	// 연결된 frame 해제
-// 	if (page->frame) {
-// 		palloc_free_page(page->frame->kva);
-// 		free(page->frame);
-// 	}
-// 	free(page);
-// }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -186,12 +186,17 @@ vm_get_frame(void)
 
 /* Growing the stack. */
 static void
-vm_stack_growth(void *addr UNUSED)
+vm_stack_growth(void *addr)
 {
 	/* 25.05.30 정진영 작성
+	 * 25.06.03 정진영 수정
 	 * 스택 최하단에 익명 페이지를 추가하여 사용
 	 * addr은 PGSIZE로 내림(정렬)하여 사용 */
-	// vm_alloc_page(VM_ANON, addr, true); // 스택 최하단에 익명 페이지 추가
+	void *upage = pg_round_down(addr);
+
+	vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);	// 스택 최하단에 새 스택 페이지 할당
+	// thread_current()->user_rsp = thread_current()->tf->rsp;
+	vm_claim_page(upage);
 }
 
 /* Handle the fault on write_protected page */

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -191,17 +191,16 @@ vm_stack_growth(void *addr)
 	 * 스택 최하단에 익명 페이지를 추가하여 사용
 	 * addr은 PGSIZE로 내림(정렬)하여 사용 */
 	void *upage = pg_round_down(addr);
+	// vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);
+
 	if (spt_find_page(&thread_current()->spt, upage) != NULL)
         return;  // 이미 만들어졌으면 아무 것도 하지 않음
 
-	// bool success = vm_alloc_page(VM_ANON | VM_MARKER_0, pg_round_down(addr), 1);	// 스택 최하단에 새 스택 페이지 할당
-	// if (!success)
-	// 	return;
+	bool success = vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);	// 스택 최하단에 새 스택 페이지 할당
+	if (!success)
+		return;
 
-	// vm_claim_page(upage);
-
-	vm_alloc_page(VM_ANON | VM_MARKER_0, upage, 1);
-	thread_current()->stack_lower_bound = upage;
+	vm_claim_page(upage);
 }
 
 /* Handle the fault on write_protected page */
@@ -248,32 +247,42 @@ vm_try_handle_fault (struct intr_frame *f, void *addr, bool user, bool write, bo
 		void *rsp = user ?  f->rsp : cur->saved_user_rsp;
 
 		/* Case1: PUSH, CALL, INT 등으로 rsp보다 낮은 주소 먼저 접근 */
-		/* 스택 포인터보다 더 낮은 주소를 먼저 참조한 경우 -> 명시적으로 스택 확장 요청이 온 것 */
+		/* 스택 포인터보다 더 낮은 주소를 먼저 참조한 경우 */
 		if (cur->stack_lower_bound <= rsp - 8 && rsp - 8 == addr && addr <= USER_STACK) {
 			vm_stack_growth(addr);
-			// return true;
+			return true;
 		}
-		/* Case2: 일반적 stack 사용  e.g. 지역 변수 접근, 배열 사용 등 */
+		/* Case2: 일반적 stack 사용 */
 		else if (cur->stack_lower_bound <= rsp && rsp <= addr && addr <= USER_STACK) {
 			vm_stack_growth(addr);
-			// return true;
+			return true;
 		}
 
-		// 4. lazy load 처리
+		// /* Case1: 스택 확장을 유발하는 명령어가 rsp보다 아래 주소에 먼저 접근함  e.g. PUSH, CALL, INT */
+		// if (STACK_LIMIT <= rsp - 8 && rsp - 8 == addr && addr <= USER_STACK) {
+        //     vm_stack_growth(addr);
+		// 	return true;
+		// }
+		// /* Case2: 지역 변수 접근, 배열 사용 등  e.g. 일반적인 스택 사용 */
+		// else if (STACK_LIMIT <= rsp && rsp <= addr && addr <= USER_STACK){
+		// 	vm_stack_growth(addr);
+		// 	return true;
+		// }
+
 		struct page *page = spt_find_page(spt, addr);	
 		if (page == NULL) 
 			return false;
 
-		// 5. write 불가능한 페이지에 write 요청한 경우
-		if (write && !page->writable)
+		// 4. 존재하는 페이지지만 write 불가인 경우
+		if (write && page && !page->writable) // write 불가능한 페이지에 write 요청한 경우
 			return false;
 
-		// 6. lazy page 실제 가져오기
+		// 5. 정상적인 lazy load 요청
 		// stack growth 아니고, 기존에 SPT에 등록된 lazy page를 실제로 가져오는 path임
 		return vm_do_claim_page(page);
     }
-	// 7. not_present == false → 아직 wp 미처리라면 false
-	return false;
+
+	return false;	// 스택 확장 조건에도 맞지 않으면 fault
 }
 
 /* Free the page.
@@ -306,7 +315,7 @@ vm_do_claim_page (struct page *page)
 {
 	struct frame *frame = vm_get_frame ();
 	/* TODO: vm_get_frame이 실패하면 swap_out */
-
+	
 	frame->page = page;
 	page->frame = frame;
 
@@ -331,8 +340,8 @@ supplemental_page_table_init (struct supplemental_page_table *spt)
 
 /* Copy supplemental page table from src to dst */
 bool
-supplemental_page_table_copy (struct supplemental_page_table *dst,
-		struct supplemental_page_table *src) 
+supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
+		struct supplemental_page_table *src UNUSED) 
 {
 	struct hash_iterator i;
 	hash_first(&i, &src->pages);
@@ -349,7 +358,7 @@ supplemental_page_table_copy (struct supplemental_page_table *dst,
 		{ 	// uninit page 생성 & 초기화
 			vm_initializer *init = src_page->uninit.init;
 			void *aux = src_page->uninit.aux;
-			vm_alloc_page_with_initializer(type, upage, writable, init, aux);
+			vm_alloc_page_with_initializer(VM_ANON, upage, writable, init, aux);
 			continue;
 		}
 
@@ -361,20 +370,12 @@ supplemental_page_table_copy (struct supplemental_page_table *dst,
             aux->ofs = src_page->file.ofs;
             aux->read_bytes = src_page->file.read_bytes;
             aux->zero_bytes = src_page->file.zero_bytes;
-
-            if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, aux)) {
-				free(aux);
+            if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, aux))
                 return false;
-			}
-
-			// if (!vm_claim_page(upage))
-			// 	return false;
-
-            struct page *file_page = spt_find_page(dst, upage);
-            file_backed_initializer(file_page, type, NULL);
-            file_page->frame = src_page->frame;
-            pml4_set_page(&thread_current()->pml4, file_page->va, src_page->frame->kva, src_page->writable);
-			//memcpy(dst_page->frame->kva, src_page->frame->kva, PGSIZE); // ???
+            struct page *page = spt_find_page(dst, upage);
+            file_backed_initializer(page, type, NULL);
+            page->frame = src_page->frame;
+            pml4_set_page(thread_current()->pml4, page->va, src_page->frame->kva, src_page->writable);
             continue;
 
 		}

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -192,19 +192,16 @@ vm_stack_growth(void *addr)
 	 * 스택 최하단에 익명 페이지를 추가하여 사용
 	 * addr은 PGSIZE로 내림(정렬)하여 사용 */
 	void *upage = pg_round_down(addr);
+	vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);
 
-	if (spt_find_page(&thread_current()->spt, addr) != NULL)
-        return;  // 이미 만들어졌으면 아무 것도 하지 않음
+	// if (spt_find_page(&thread_current()->spt, addr) != NULL)
+    //     return;  // 이미 만들어졌으면 아무 것도 하지 않음
 
-	bool success = vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);	// 스택 최하단에 새 스택 페이지 할당
-	// printf("[vm_stack_growth] alloc %p %s\n", upage, success ? "SUCCESS" : "FAILURE");
-	if (!success)
-		return;
+	// bool success = vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);	// 스택 최하단에 새 스택 페이지 할당
+	// if (!success)
+	// 	return;
 
-	vm_claim_page(upage);
-	// bool claimed = vm_claim_page(upage);
-	// printf("[vm_stack_growth] claim %p %s\n", upage, claimed ? "SUCCESS" : "FAILURE");
-	// ASSERT(claimed);
+	// vm_claim_page(upage);
 }
 
 /* Handle the fault on write_protected page */
@@ -234,38 +231,40 @@ vm_try_handle_fault (struct intr_frame *f, void *addr, bool user, bool write, bo
 	if (addr == NULL || is_kernel_vaddr(addr))
 		return false;
 
-	struct page *page = spt_find_page(spt, addr);
-
-	// [TBD] 2. Write-protection fault (present but write to r/o page) 
-	if (!not_present && write)
-	// 	return vm_handle_wp(page);
-		return false;
+	// [TBD] 2. Write-protection fault (present but write to r/o page) 	// 이거 나중에 3번 뒤로 보내야 함
+	// if (!not_present && write)
+	// // 	return vm_handle_wp(page);
+	// 	return false;
 
 	// 3. Stack Growth 케이스
-	if (not_present && page == NULL) 
+	if (not_present) 
 	{
 		void *rsp = user ?  f->rsp : cur->user_rsp;
 
 		/* Case1: 스택 확장을 유발하는 명령어가 rsp보다 아래 주소에 먼저 접근함  e.g. PUSH, CALL, INT */
-		if (STACK_LIMIT <= rsp - 8 && rsp - 8 == addr && addr <= USER_STACK) {
+		if (STACK_LIMIT <= rsp - 8 && rsp - 8 <= addr && addr <= USER_STACK) {
             vm_stack_growth(addr);
 			return true;
 		}
-		/* Case2: 지역 변수 접근, 배열 사용 등  e.g. 일반적인 스택 사용 */
-		else if (STACK_LIMIT <= rsp && rsp <= addr && addr <= USER_STACK){
-			vm_stack_growth(addr);
-			return true;
-		}
+		// /* Case2: 지역 변수 접근, 배열 사용 등  e.g. 일반적인 스택 사용 */
+		// else if (STACK_LIMIT <= rsp && rsp <= addr && addr <= USER_STACK){
+		// 	vm_stack_growth(addr);
+		// 	return true;
+		// }
 
-		return false;	// 스택 확장 조건에도 맞지 않으면 fault
+		struct page *page = spt_find_page(spt, addr);	
+		if (page == NULL) 
+			return false;
+
+		// 4. 존재하는 페이지지만 write 불가인 경우
+		if (write && page && !page->writable) // write 불가능한 페이지에 write 요청한 경우
+			return false;
+
+		// 5. 정상적인 lazy load 요청
+		return vm_do_claim_page(page);
     }
 
-	// 4. 존재하는 페이지지만 write 불가인 경우
-	if (write && page && !page->writable) // write 불가능한 페이지에 write 요청한 경우
-		return false;	
-
-	// 5. 정상적인 lazy load 요청
-	return vm_do_claim_page(page);
+	return false;	// 스택 확장 조건에도 맞지 않으면 fault
 }
 
 /* Free the page.
@@ -308,8 +307,9 @@ vm_do_claim_page (struct page *page)
 	/* TODO: Insert page table entry to map page's VA to frame's PA. */
 	/* 페이지의 VA와 프레임의 KVA를 페이지 테이블에 매핑 */
 	struct thread *current = thread_current();
-    pml4_set_page(current->pml4, page->va, frame->kva, page->writable);
-
+	if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable)) {
+		return false;
+	}
 	return swap_in(page, frame->kva);
 }
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -119,14 +119,8 @@ spt_insert_page (struct supplemental_page_table *spt UNUSED, struct page *page U
 void
 spt_remove_page (struct supplemental_page_table *spt, struct page *page) 
 {
+	hash_delete(&thread_current()->spt.pages, &page->hash_elem);
 	vm_dealloc_page (page);
-
-	/** TODO: page 해제
-	 * 매핑된 프레임을 해제해야하나?
-	 * 프레임이 스왑되어있는지 체크할것?
-	 * 아마 pml4_clear_page 사용하면 된대요
-	 */
-
 	return true;
 }
 
@@ -316,14 +310,32 @@ supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
 
 		/* 1) type이 uninit이면 */
 		if (type == VM_UNINIT)
-		{ // uninit page 생성 & 초기화
+		{ 	// uninit page 생성 & 초기화
 			vm_initializer *init = src_page->uninit.init;
 			void *aux = src_page->uninit.aux;
 			vm_alloc_page_with_initializer(VM_ANON, upage, writable, init, aux);
 			continue;
 		}
 
-		/* 2) type이 uninit이 아니면 */
+		/* 2) type이 file이면{ */
+		if (type == VM_FILE) 
+		{	// file 
+			struct lazy_load_arg *aux = malloc(sizeof(struct lazy_load_arg));
+            aux->file = src_page->file.file;
+            aux->ofs = src_page->file.ofs;
+            aux->read_bytes = src_page->file.read_bytes;
+            aux->zero_bytes = src_page->file.zero_bytes;
+            if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, aux))
+                return false;
+            struct page *page = spt_find_page(dst, upage);
+            file_backed_initializer(page, type, NULL);
+            page->frame = src_page->frame;
+            pml4_set_page(thread_current()->pml4, page->va, src_page->frame->kva, src_page->writable);
+            continue;
+
+		}
+
+		/* 3) type이 uninit이 아니면 */
 		if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, NULL)) // uninit page 생성 & 초기화
 			// init(lazy_load_segment)는 page_fault가 발생할때 호출됨
 			// 지금 만드는 페이지는 page_fault가 일어날 때까지 기다리지 않고 바로 내용을 넣어줘야 하므로 필요 없음

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -48,6 +48,7 @@ static bool vm_do_claim_page(struct page *page);
 static struct frame *vm_evict_frame(void);
 
 /* 25.06.01 고재웅 작성
+ * 25.06.02 정진영 수정 (주석 추가, 페이지 구조체 할당 실패 처리, switch 문 default 추가)
  * 초기화 함수와 함께 대기 중인 페이지 객체를 생성한다. 페이지를 직접 생성하지 말고,
  * 반드시 이 함수나 `vm_alloc_page`를 통해 생성하라. 
  * 페이지를 할당하고 타입을 uninit으로 설정한다.
@@ -56,19 +57,24 @@ bool
 vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
 									vm_initializer *init, void *aux)
 {
-
+	// 1. UNINIT이 아닌 실제 타입만 이 함수로 생성 가능 (VM_ANON, VM_FILE 등)
 	ASSERT(VM_TYPE(type) != VM_UNINIT)
 
+	// 2. 현재 스레드의 spt 획득
 	struct supplemental_page_table *spt = &thread_current ()->spt;
 
-	/* Check wheter the upage is already occupied or not. */
+	// 3. 이미 해당 가상 주소(upage)에 페이지가 존재한다면 중복 삽입 방지
 	if (spt_find_page (spt, upage) == NULL) {
 		/* TODO: 페이지를 생성하고, VM 유형에 따라 초기화 파일을 가져옵니다.Add commentMore actions
 		 * TODO: 그런 다음 uninit_new를 호출하여 "uninit" 페이지 구조체를 생성합니다.
 		 * TODO: uninit_new를 호출한 후 필드를 수정해야 합니다. */
-		struct page *p = (struct page *)malloc(sizeof(struct page));
-		bool (*page_initializer)(struct page *, enum vm_type, void *);
 
+		// 4. 새로운 page 구조체 동적 할당
+		struct page *p = (struct page *)malloc(sizeof(struct page));
+		if (p == NULL) return false;
+
+		// 5. 유형별 초기화 함수 선택 (UNINIT → 실제 타입으로 변환될 때 호출됨)
+		bool (*page_initializer)(struct page *, enum vm_type, void *);
 		switch (VM_TYPE(type))
 		{
 			case VM_ANON:
@@ -77,11 +83,14 @@ vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
 			case VM_FILE:
 				page_initializer = file_backed_initializer;
 				break;
+			default:
+    			PANIC("Invalid VM type in vm_alloc_page_with_initializer");
 		}
-		/* TODO: spt에 페이지를 삽입합니다. */
+		// 6. uninit_new: lazy-loading용 uninit 페이지를 구성 & 쓰기 가능 여부 설정
 		uninit_new(p, upage, init, type, aux, page_initializer);
 		p->writable = writable;
 
+		// 7. spt에 페이지 등록
 		return spt_insert_page(spt, p);
 	}
 err:
@@ -113,7 +122,8 @@ bool
 spt_insert_page (struct supplemental_page_table *spt UNUSED, struct page *page UNUSED) 
 {
 	/* TODO: Fill this function. */
-	return hash_insert(&spt->pages, &page->hash_elem) == NULL ? true : false;
+	// return hash_insert(&spt->pages, &page->hash_elem) == NULL ? true : false;
+	return hash_insert(&spt->pages, &page->hash_elem) == NULL;
 }
 
 void
@@ -170,8 +180,11 @@ vm_get_frame(void)
 
 	// 2. 할당 실패 시 PANIC
 	if (kva == NULL) {
-		// 추후 페이지 교체를 추가해야 한다.
-		PANIC("todo: implement eviction here");
+		/* 추후 페이지 교체를 추가해야 한다.  
+		 * OS를 중지시키고, 소스 파일명, 라인 번호, 함수명 등의 정보와 함께 사용자 지정 메시지를 출력 
+		 * e.g. try_to_evict_and_allocate()
+		 */
+		PANIC("todo: implement eviction here");	
 	}
 
 	// 3. 프레임 구조체 할당 및 초기화
@@ -201,14 +214,12 @@ vm_handle_wp (struct page *page UNUSED)
 }
 
 /* 25.06.01 고재웅 작성 */
-/* Return true on success 
- * 페이지 폴트 핸들러 - 페이지 폴트 발생시 제어권을 전달 받는다.
- * 물리 프레임이 존재하지 않아서 발생한 예외는 not_present 가 true다
- * 그 경우 물리 프레임 할당을 요청하는 vm_do_claim_page를 호출한다.
- * 반대로 not_present 가 false인 경우는 물리 프레임이 할당되어 있지만 폴트가 발생한 것이다.
- * read-only page에 write를 한경우 등 이 때에는 예외 처리를 하면 된다.
- * 그렇다고 해서 not_present가 true인 경우에서 read-only page에 요청을 할 수 있으니 이에
- * 대한 예외를 처리하라
+/* 
+ * 페이지 폴트 핸들러 함수
+ * - not_present == true: 물리 프레임이 없어서 발생한 예외
+ *   → 새로운 프레임을 할당해서 해결 가능 (vm_do_claim_page 호출)
+ * - not_present == false: 페이지는 있지만 권한 문제 등으로 예외 발생
+ *   → read-only 페이지에 write 시도 등 → 실패 처리
  */
 bool
 vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
@@ -216,25 +227,29 @@ vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
 {
 	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
 	struct page *page = NULL;
-	/* TODO: Validate the fault */
-	/* TODO: Your code goes here */
-	// 1. 주소 유효성 검사
-	if (addr == NULL)
+	
+	// 1. 예외 주소 유효성 검사
+	if (addr == NULL)			// NULL 포인터 접근
 		return false;
 
-	if (is_kernel_vaddr(addr))
+	if (is_kernel_vaddr(addr))	// 커널 주소 접근은 유저 코드에서 금지
 		return false;
 
-	if (not_present) // 접근한 메모리의 physical page가 존재하지 않은 경우
-    {
-        /* TODO: Validate the fault */
+	// 2. 물리 프레임이 없는 경우 → lazy page 등 처리 가능
+	if (not_present) {
+        // 2-1. spt에서 해당 주소의 페이지 정보 검색
         page = spt_find_page(spt, addr);
         if (page == NULL)
+            return false;		// 페이지 정보가 없다면 처리 불가
+
+		// 2-2. 쓰기 요청인데 쓰기 불가능한 페이지인 경우 → 예외
+        if (write == 1 && page->writable == 0) 
             return false;
-        if (write == 1 && page->writable == 0) // write 불가능한 페이지에 write 요청한 경우
-            return false;
+		
+		// 2-3. 페이지를 실체화하여 매핑 시도
         return vm_do_claim_page(page);
     }
+	// 3. 페이지는 있지만 권한 문제 등 → 실패 처리
     return false;
 }
 
@@ -248,10 +263,11 @@ vm_dealloc_page (struct page *page)
 }
 
 /* 25.06.01 고재웅 수정
+
  * VA에 해당하는 페이지를 가져온다. 
  * 해당 페이지로 vm_do_claim_page를 호출한다. */
 bool
-vm_claim_page (void *va UNUSED) 
+vm_claim_page (void *va) 
 {
 	/* TODO: Fill this function */
 	struct page *page = NULL;
@@ -263,6 +279,7 @@ vm_claim_page (void *va UNUSED)
 }
 
 /* 25.06.01 고재웅 수정
+ * 25.06.02 정진영 수정 (실패 처리 추가)
  * 인자로 주어진 page에 frame을 할당 한다. --> vm_get_frame()
  * mmu를 설정한다.(pml4) */
 static bool
@@ -270,6 +287,8 @@ vm_do_claim_page (struct page *page)
 {
 	struct frame *frame = vm_get_frame ();
 	/* TODO: vm_get_frame이 실패하면 swap_out */
+	if (frame == NULL)
+		PANIC("Failed to allocate frame (eviction not yet implemented)"); // or return false;
 	
 	/* Set links */
 	frame->page = page;
@@ -278,13 +297,16 @@ vm_do_claim_page (struct page *page)
 	/* TODO: Insert page table entry to map page's VA to frame's PA. */
 	/* 페이지의 VA와 프레임의 KVA를 페이지 테이블에 매핑 */
 	struct thread *current = thread_current();
-    pml4_set_page(current->pml4, page->va, frame->kva, page->writable);
+    bool success = pml4_set_page(current->pml4, page->va, frame->kva, page->writable);
+	if (!success)
+	PANIC("pml4_set_page failed: possible double mapping or invalid VA");
 
 	return swap_in(page, frame->kva);
 }
 
 /* Initialize new supplemental page table */
-/* 25.05.30 고재웅 작성 */
+/* 25.05.30 고재웅 작성
+ * 25.06.02 정진영 수정 (주석 추가) */
 
 /* 프로세스가 시작될 때(initd) or 포크될 때(__do_fork) 호출되는 함수 */
 void
@@ -297,50 +319,62 @@ supplemental_page_table_init (struct supplemental_page_table *spt UNUSED)
 /* Copy supplemental page table from src to dst */
 bool
 supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
-		struct supplemental_page_table *src UNUSED) 
+								struct supplemental_page_table *src UNUSED) 
 {
+	// src SPT를 순회할 hash iterator 준비
 	struct hash_iterator i;
 	hash_first(&i, &src->pages);
-	while (hash_next(&i))
-	{
-		// src_page 정보
+
+	// src의 모든 page를 순회
+	while (hash_next(&i)) { 
+		// 현재 해시 엔트리에서 page 구조체 추출
 		struct page *src_page = hash_entry(hash_cur(&i), struct page, hash_elem);
+
+		// src page 정보 복사
 		enum vm_type type = src_page->operations->type;
 		void *upage = src_page->va;
 		bool writable = src_page->writable;
 
-		/* 1) type이 uninit이면 */
-		if (type == VM_UNINIT)
-		{ // uninit page 생성 & 초기화
+		/* 1) uninit type */
+		if (type == VM_UNINIT) { 
+			// 초기화 정보(지연 로딩 함수, aux 데이터) 복사	
 			vm_initializer *init = src_page->uninit.init;
 			void *aux = src_page->uninit.aux;
-			vm_alloc_page_with_initializer(VM_ANON, upage, writable, init, aux);
+
+			// dst SPT에 UNINIT page 등록
+			if (!vm_alloc_page_with_initializer(type, upage, writable, init, aux))
+				goto err;
 			continue;
 		}
 
-		/* 2) type이 uninit이 아니면 */
-		if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, NULL)) // uninit page 생성 & 초기화
+		/* 2) Not uninit type */
+		// 새로 초기화 페이지 등록 (init은 NULL, 즉 lazy load 아님)
+		if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, NULL))
 			// init(lazy_load_segment)는 page_fault가 발생할때 호출됨
 			// 지금 만드는 페이지는 page_fault가 일어날 때까지 기다리지 않고 바로 내용을 넣어줘야 하므로 필요 없음
 			return false;
 
-		// vm_claim_page으로 요청해서 매핑 & 페이지 타입에 맞게 초기화
+		// 페이지를 바로 매핑 및 프레임 할당 (실제 물리 메모리 확보)
 		if (!vm_claim_page(upage))
 			return false;
 
-		// 매핑된 프레임에 내용 로딩
-		struct page *dst_page = spt_find_page(dst, upage);
-		memcpy(dst_page->frame->kva, src_page->frame->kva, PGSIZE);
+		struct page *dst_page = spt_find_page(dst, upage);			// dst의 페이지 구조체 가져옴
+		memcpy(dst_page->frame->kva, src_page->frame->kva, PGSIZE);	// src 프레임 데이터를 dst 프레임으로 복사
 	}
 	return true;
+
+err:
+	supplemental_page_table_kill(dst); // cleanup
+	return false;
 }
 
 /* Free the resource hold by the supplemental page table */
 void
 supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED) 
 {
-	/* TODO: 스레드가 보유한 모든 supplemental_page_table을 제거하고,
-	 * TODO: 수정된 내용을 스토리지에 기록(writeback)하세요. */
+	// 해시 테이블의 모든 페이지 구조체를 순회하며 spt 제거
+	// 각 엔트리는 hash_page_destroy() 함수에 의해 해제됨
+	// 수정된 내용을 스토리지에 기록(writeback)
 	hash_clear(&spt->pages, hash_page_destroy);
 }
 
@@ -356,7 +390,8 @@ uint64_t page_hash(const struct hash_elem *e, void *aux){
 /* 두 page의 va를 기준으로 정렬을 비교한다. */
 bool page_less(const struct hash_elem *a, const struct hash_elem *b, void *aux){
 	/* 이 함수는 해시 테이블 충돌 시 내부 정렬에 사용된다고 한다. */
-	struct page *pa = hash_entry(a, struct page, hash_elem);
+	struct page *pa = hash_entry
+	(a, struct page, hash_elem);
 	struct page *pb = hash_entry(b, struct page, hash_elem);
 	return pa->va < pb->va;
 }
@@ -367,3 +402,20 @@ void hash_page_destroy(struct hash_elem *e, void *aux)
 	destroy(page);
 	free(page);
 }
+
+// void hash_page_destroy(struct hash_elem *e, void *aux)
+// {
+// 	struct page *page = hash_entry(e, struct page, hash_elem);
+// 	// destroy(page);
+
+// 	// destroy 함수 등록되어 있다면 호출
+// 	if (page->operations && page->operations->destroy)
+// 	page->operations->destroy(page);
+
+// 	// 연결된 frame 해제
+// 	if (page->frame) {
+// 		palloc_free_page(page->frame->kva);
+// 		free(page->frame);
+// 	}
+// 	free(page);
+// }

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -11,6 +11,7 @@
 /* 25.05.30 고재웅 작성 */
 #include <hash.h>
 #include "threads/vaddr.h"
+#include "userprog/process.h"
 
 /* 각 서브시스템의 초기화 코드를 호출하여 가상 메모리 서브시스템을 초기화합니다. */
 void 
@@ -46,6 +47,9 @@ page_get_type(struct page *page)
 static struct frame *vm_get_victim(void);
 static bool vm_do_claim_page(struct page *page);
 static struct frame *vm_evict_frame(void);
+static struct frame *vm_get_frame(void);
+static bool vm_handle_wp (struct page *page UNUSED);
+
 
 /* 25.06.01 고재웅 작성
  * 초기화 함수와 함께 대기 중인 페이지 객체를 생성한다. 페이지를 직접 생성하지 말고,
@@ -184,16 +188,27 @@ vm_stack_growth(void *addr)
 {
 	/* 25.05.30 정진영 작성
 	 * 25.06.03 정진영 수정
+	 * 25.06.06 정진영 수정
 	 * 스택 최하단에 익명 페이지를 추가하여 사용
 	 * addr은 PGSIZE로 내림(정렬)하여 사용 */
 	void *upage = pg_round_down(addr);
 
-	vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);	// 스택 최하단에 새 스택 페이지 할당
-	// thread_current()->user_rsp = thread_current()->tf->rsp;
+	if (spt_find_page(&thread_current()->spt, addr) != NULL)
+        return;  // 이미 만들어졌으면 아무 것도 하지 않음
+
+	bool success = vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);	// 스택 최하단에 새 스택 페이지 할당
+	// printf("[vm_stack_growth] alloc %p %s\n", upage, success ? "SUCCESS" : "FAILURE");
+	if (!success)
+		return;
+
 	vm_claim_page(upage);
+	// bool claimed = vm_claim_page(upage);
+	// printf("[vm_stack_growth] claim %p %s\n", upage, claimed ? "SUCCESS" : "FAILURE");
+	// ASSERT(claimed);
 }
 
 /* Handle the fault on write_protected page */
+/* Copy on Write 과제용 */
 static bool
 vm_handle_wp (struct page *page UNUSED) 
 {
@@ -210,31 +225,47 @@ vm_handle_wp (struct page *page UNUSED)
  * 대한 예외를 처리하라
  */
 bool
-vm_try_handle_fault (struct intr_frame *f UNUSED, void *addr UNUSED,
-		bool user UNUSED, bool write UNUSED, bool not_present UNUSED) 
+vm_try_handle_fault (struct intr_frame *f, void *addr, bool user, bool write, bool not_present) 
 {
-	struct supplemental_page_table *spt UNUSED = &thread_current ()->spt;
-	struct page *page = NULL;
-	/* TODO: Validate the fault */
-	/* TODO: Your code goes here */
+	struct thread *cur = thread_current();
+	struct supplemental_page_table *spt = &cur->spt;
+
 	// 1. 주소 유효성 검사
-	if (addr == NULL)
+	if (addr == NULL || is_kernel_vaddr(addr))
 		return false;
 
-	if (is_kernel_vaddr(addr))
+	struct page *page = spt_find_page(spt, addr);
+
+	// [TBD] 2. Write-protection fault (present but write to r/o page) 
+	if (!not_present && write)
+	// 	return vm_handle_wp(page);
 		return false;
 
-	if (not_present) // 접근한 메모리의 physical page가 존재하지 않은 경우
-    {
-        /* TODO: Validate the fault */
-        page = spt_find_page(spt, addr);
-        if (page == NULL)
-            return false;
-        if (write == 1 && page->writable == 0) // write 불가능한 페이지에 write 요청한 경우
-            return false;
-        return vm_do_claim_page(page);
+	// 3. Stack Growth 케이스
+	if (not_present && page == NULL) 
+	{
+		void *rsp = user ?  f->rsp : cur->user_rsp;
+
+		/* Case1: 스택 확장을 유발하는 명령어가 rsp보다 아래 주소에 먼저 접근함  e.g. PUSH, CALL, INT */
+		if (STACK_LIMIT <= rsp - 8 && rsp - 8 == addr && addr <= USER_STACK) {
+            vm_stack_growth(addr);
+			return true;
+		}
+		/* Case2: 지역 변수 접근, 배열 사용 등  e.g. 일반적인 스택 사용 */
+		else if (STACK_LIMIT <= rsp && rsp <= addr && addr <= USER_STACK){
+			vm_stack_growth(addr);
+			return true;
+		}
+
+		return false;	// 스택 확장 조건에도 맞지 않으면 fault
     }
-    return false;
+
+	// 4. 존재하는 페이지지만 write 불가인 경우
+	if (write && page && !page->writable) // write 불가능한 페이지에 write 요청한 경우
+		return false;	
+
+	// 5. 정상적인 lazy load 요청
+	return vm_do_claim_page(page);
 }
 
 /* Free the page.

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -13,6 +13,8 @@
 #include "threads/vaddr.h"
 #include "userprog/process.h"
 
+struct lock frame_lock;		/* 25.06.06 정진영 작성 */
+
 /* 각 서브시스템의 초기화 코드를 호출하여 가상 메모리 서브시스템을 초기화합니다. */
 void 
 vm_init (void)
@@ -23,9 +25,9 @@ vm_init (void)
 	pagecache_init();
 #endif
 	register_inspect_intr();
-	/* 이 위쪽은 수정하지 마세요 !! */
-	/* TODO: 이 아래쪽부터 코드를 추가하세요 */
+
 	list_init(&frame_table);	/* 25.05.30 고재웅 작성 */
+	lock_init(&frame_lock);		/* 25.06.06 정진영 작성 */
 }
 
 /* 페이지의 타입을 가져옵니다. 이 함수는 페이지가 초기화된 후 타입을 알고 싶을 때 유용합니다.
@@ -70,20 +72,26 @@ vm_alloc_page_with_initializer(enum vm_type type, void *upage, bool writable,
 		/* TODO: 페이지를 생성하고, VM 유형에 따라 초기화 파일을 가져옵니다.Add commentMore actions
 		 * TODO: 그런 다음 uninit_new를 호출하여 "uninit" 페이지 구조체를 생성합니다.
 		 * TODO: uninit_new를 호출한 후 필드를 수정해야 합니다. */
-		struct page *p = (struct page *)malloc(sizeof(struct page));
-		bool (*page_initializer)(struct page *, enum vm_type, void *);
+		struct page *p = malloc(sizeof(struct page));
+		if (!p)
+			goto err;
+		
+		typedef bool (*initializer_by_type)(struct page *, enum vm_type, void *);
+		initializer_by_type initializer = NULL;
 
 		switch (VM_TYPE(type))
 		{
 			case VM_ANON:
-				page_initializer = anon_initializer;
+				initializer = anon_initializer;
 				break;
 			case VM_FILE:
-				page_initializer = file_backed_initializer;
+				initializer = file_backed_initializer;
 				break;
+			default:
+				goto err;
 		}
 		/* TODO: spt에 페이지를 삽입합니다. */
-		uninit_new(p, upage, init, type, aux, page_initializer);
+		uninit_new(p, upage, init, type, aux, initializer);
 		p->writable = writable;
 
 		return spt_insert_page(spt, p);
@@ -98,9 +106,7 @@ err:
 * 가상 주소를 통해 SPT에서 페이지를 찾아 리턴한다.
 * 에러가 발생하면 NULL을 리턴 */
 struct page *
-spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
-
-	/* TODO: Fill this function. */
+spt_find_page (struct supplemental_page_table *spt, void *va) {
 	struct page key;
 	key.va = pg_round_down(va);
 
@@ -116,13 +122,12 @@ spt_find_page (struct supplemental_page_table *spt UNUSED, void *va UNUSED) {
 bool
 spt_insert_page (struct supplemental_page_table *spt UNUSED, struct page *page UNUSED) 
 {
-	/* TODO: Fill this function. */
 	return hash_insert(&spt->pages, &page->hash_elem) == NULL ? true : false;
 }
 
 void
 spt_remove_page (struct supplemental_page_table *spt, struct page *page) 
-{
+{	// 아직까지는 불리우는 곳 없는 함수
 	hash_delete(&thread_current()->spt.pages, &page->hash_elem);
 	vm_dealloc_page (page);
 	return true;
@@ -160,24 +165,18 @@ vm_evict_frame (void)
 static struct frame *
 vm_get_frame(void)
 {
-	/* TODO: Fill this function. */
-	struct frame *frame = NULL;
+	struct frame *frame = (struct frame *)malloc(sizeof(struct frame));
+	ASSERT (frame != NULL);
 
-	// 1. 유저 풀에서 새로운 페이지 할당
-	void *kva = palloc_get_page(PAL_USER);
+	frame->kva = palloc_get_page(PAL_USER | PAL_ZERO);  
 
-	// 2. 할당 실패 시 PANIC
-	if (kva == NULL) {
-		// 추후 페이지 교체를 추가해야 한다.
-		PANIC("todo: implement eviction here");
-	}
+	if (frame->kva == NULL)
+		frame = vm_evict_frame();
+	else
+		list_push_back(&frame_table, &frame->elem);
 
-	// 3. 프레임 구조체 할당 및 초기화
-	frame = (struct frame *)malloc(sizeof(struct frame)); 
-	frame->kva = kva; // 프레임의 물리 주소 (kva는 물리 주소를 커널의 가상 주소로 1대 1로 매핑해 놓았다.)
 	frame->page = NULL;
 
-	ASSERT(frame != NULL);
 	ASSERT(frame->page == NULL);
 	return frame;
 }
@@ -192,16 +191,17 @@ vm_stack_growth(void *addr)
 	 * 스택 최하단에 익명 페이지를 추가하여 사용
 	 * addr은 PGSIZE로 내림(정렬)하여 사용 */
 	void *upage = pg_round_down(addr);
-	vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);
+	if (spt_find_page(&thread_current()->spt, upage) != NULL)
+        return;  // 이미 만들어졌으면 아무 것도 하지 않음
 
-	// if (spt_find_page(&thread_current()->spt, addr) != NULL)
-    //     return;  // 이미 만들어졌으면 아무 것도 하지 않음
-
-	// bool success = vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);	// 스택 최하단에 새 스택 페이지 할당
+	// bool success = vm_alloc_page(VM_ANON | VM_MARKER_0, pg_round_down(addr), 1);	// 스택 최하단에 새 스택 페이지 할당
 	// if (!success)
 	// 	return;
 
 	// vm_claim_page(upage);
+
+	vm_alloc_page(VM_ANON | VM_MARKER_0, upage, 1);
+	thread_current()->stack_lower_bound = upage;
 }
 
 /* Handle the fault on write_protected page */
@@ -209,6 +209,7 @@ vm_stack_growth(void *addr)
 static bool
 vm_handle_wp (struct page *page UNUSED) 
 {
+	return false;
 }
 
 /* 25.06.01 고재웅 작성 */
@@ -239,32 +240,40 @@ vm_try_handle_fault (struct intr_frame *f, void *addr, bool user, bool write, bo
 	// 3. Stack Growth 케이스
 	if (not_present) 
 	{
-		void *rsp = user ?  f->rsp : cur->user_rsp;
+		/* f->rsp: 인터럽트 발생 당시 유저 모드의 %rsp 값 
+		 * cur->saved_user_rsp: 커널 모드 스택에서 저장해둔 유저 모드 %rsp 값
+		 * 즉, stack growth 판단 시 기준이 되는 rsp는 항상 유저 스택 rsp여야 하기 때문에
+		 * user mode/kernel mode fault 인지에 따라 정확한 유저 스택 기준을 얻기 위함
+		 */
+		void *rsp = user ?  f->rsp : cur->saved_user_rsp;
 
-		/* Case1: 스택 확장을 유발하는 명령어가 rsp보다 아래 주소에 먼저 접근함  e.g. PUSH, CALL, INT */
-		if (STACK_LIMIT <= rsp - 8 && rsp - 8 <= addr && addr <= USER_STACK) {
-            vm_stack_growth(addr);
-			return true;
+		/* Case1: PUSH, CALL, INT 등으로 rsp보다 낮은 주소 먼저 접근 */
+		/* 스택 포인터보다 더 낮은 주소를 먼저 참조한 경우 -> 명시적으로 스택 확장 요청이 온 것 */
+		if (cur->stack_lower_bound <= rsp - 8 && rsp - 8 == addr && addr <= USER_STACK) {
+			vm_stack_growth(addr);
+			// return true;
 		}
-		// /* Case2: 지역 변수 접근, 배열 사용 등  e.g. 일반적인 스택 사용 */
-		// else if (STACK_LIMIT <= rsp && rsp <= addr && addr <= USER_STACK){
-		// 	vm_stack_growth(addr);
-		// 	return true;
-		// }
+		/* Case2: 일반적 stack 사용  e.g. 지역 변수 접근, 배열 사용 등 */
+		else if (cur->stack_lower_bound <= rsp && rsp <= addr && addr <= USER_STACK) {
+			vm_stack_growth(addr);
+			// return true;
+		}
 
+		// 4. lazy load 처리
 		struct page *page = spt_find_page(spt, addr);	
 		if (page == NULL) 
 			return false;
 
-		// 4. 존재하는 페이지지만 write 불가인 경우
-		if (write && page && !page->writable) // write 불가능한 페이지에 write 요청한 경우
+		// 5. write 불가능한 페이지에 write 요청한 경우
+		if (write && !page->writable)
 			return false;
 
-		// 5. 정상적인 lazy load 요청
+		// 6. lazy page 실제 가져오기
+		// stack growth 아니고, 기존에 SPT에 등록된 lazy page를 실제로 가져오는 path임
 		return vm_do_claim_page(page);
     }
-
-	return false;	// 스택 확장 조건에도 맞지 않으면 fault
+	// 7. not_present == false → 아직 wp 미처리라면 false
+	return false;
 }
 
 /* Free the page.
@@ -280,14 +289,12 @@ vm_dealloc_page (struct page *page)
  * VA에 해당하는 페이지를 가져온다. 
  * 해당 페이지로 vm_do_claim_page를 호출한다. */
 bool
-vm_claim_page (void *va UNUSED) 
+vm_claim_page (void *va) 
 {
-	/* TODO: Fill this function */
-	struct page *page = NULL;
-	page = spt_find_page(&thread_current()->spt, va);
-	if (page == NULL){
+	struct page *page = spt_find_page(&thread_current()->spt, va);
+	if (page == NULL)
 		return false;
-	}
+
 	return vm_do_claim_page (page);
 }
 
@@ -299,17 +306,15 @@ vm_do_claim_page (struct page *page)
 {
 	struct frame *frame = vm_get_frame ();
 	/* TODO: vm_get_frame이 실패하면 swap_out */
-	
-	/* Set links */
+
 	frame->page = page;
 	page->frame = frame;
 
 	/* TODO: Insert page table entry to map page's VA to frame's PA. */
 	/* 페이지의 VA와 프레임의 KVA를 페이지 테이블에 매핑 */
-	struct thread *current = thread_current();
-	if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable)) {
+	if (!pml4_set_page(thread_current()->pml4, page->va, frame->kva, page->writable))
 		return false;
-	}
+
 	return swap_in(page, frame->kva);
 }
 
@@ -318,16 +323,16 @@ vm_do_claim_page (struct page *page)
 
 /* 프로세스가 시작될 때(initd) or 포크될 때(__do_fork) 호출되는 함수 */
 void
-supplemental_page_table_init (struct supplemental_page_table *spt UNUSED) 
+supplemental_page_table_init (struct supplemental_page_table *spt) 
 {
 	/* SPT 초기화시 hash_init에 아래 작성한 page_hash, page_less를 포함한다. */
-	hash_init(&spt->pages, page_hash, page_less, NULL);
+	hash_init(spt, page_hash, page_less, NULL);
 }
 
 /* Copy supplemental page table from src to dst */
 bool
-supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
-		struct supplemental_page_table *src UNUSED) 
+supplemental_page_table_copy (struct supplemental_page_table *dst,
+		struct supplemental_page_table *src) 
 {
 	struct hash_iterator i;
 	hash_first(&i, &src->pages);
@@ -344,7 +349,7 @@ supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
 		{ 	// uninit page 생성 & 초기화
 			vm_initializer *init = src_page->uninit.init;
 			void *aux = src_page->uninit.aux;
-			vm_alloc_page_with_initializer(VM_ANON, upage, writable, init, aux);
+			vm_alloc_page_with_initializer(type, upage, writable, init, aux);
 			continue;
 		}
 
@@ -356,12 +361,20 @@ supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
             aux->ofs = src_page->file.ofs;
             aux->read_bytes = src_page->file.read_bytes;
             aux->zero_bytes = src_page->file.zero_bytes;
-            if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, aux))
+
+            if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, aux)) {
+				free(aux);
                 return false;
-            struct page *page = spt_find_page(dst, upage);
-            file_backed_initializer(page, type, NULL);
-            page->frame = src_page->frame;
-            pml4_set_page(thread_current()->pml4, page->va, src_page->frame->kva, src_page->writable);
+			}
+
+			// if (!vm_claim_page(upage))
+			// 	return false;
+
+            struct page *file_page = spt_find_page(dst, upage);
+            file_backed_initializer(file_page, type, NULL);
+            file_page->frame = src_page->frame;
+            pml4_set_page(&thread_current()->pml4, file_page->va, src_page->frame->kva, src_page->writable);
+			//memcpy(dst_page->frame->kva, src_page->frame->kva, PGSIZE); // ???
             continue;
 
 		}
@@ -397,7 +410,7 @@ supplemental_page_table_kill (struct supplemental_page_table *spt UNUSED)
 
 /* page_hash 가상 주소를 바탕으로 해시값을 계산한다. */
 uint64_t page_hash(const struct hash_elem *e, void *aux){
-	const struct page *p = hash_entry(e, struct page, hash_elem);
+	struct page *p = hash_entry(e, struct page, hash_elem);
 	return hash_bytes(&p->va, sizeof(p->va));
 }
 

--- a/vm/vm.c
+++ b/vm/vm.c
@@ -185,22 +185,21 @@ vm_get_frame(void)
 static void
 vm_stack_growth(void *addr)
 {
-	/* 25.05.30 정진영 작성
-	 * 25.06.03 정진영 수정
-	 * 25.06.06 정진영 수정
-	 * 스택 최하단에 익명 페이지를 추가하여 사용
-	 * addr은 PGSIZE로 내림(정렬)하여 사용 */
 	void *upage = pg_round_down(addr);
-	// vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);
 
 	if (spt_find_page(&thread_current()->spt, upage) != NULL)
         return;  // 이미 만들어졌으면 아무 것도 하지 않음
 
-	bool success = vm_alloc_page(VM_ANON | VM_MARKER_0, upage, true);	// 스택 최하단에 새 스택 페이지 할당
-	if (!success)
-		return;
+	if (vm_alloc_page(VM_ANON | VM_MARKER_0, upage, 1)) {
+		// 스택 최하단에 새 스택 페이지 할당
+		bool success = vm_claim_page(upage);
 
-	vm_claim_page(upage);
+		if (success) {
+			if (upage < thread_current()->stack_lower_bound) {
+            	thread_current()->stack_lower_bound = upage;
+			}
+        }
+	}
 }
 
 /* Handle the fault on write_protected page */
@@ -258,31 +257,21 @@ vm_try_handle_fault (struct intr_frame *f, void *addr, bool user, bool write, bo
 			return true;
 		}
 
-		// /* Case1: 스택 확장을 유발하는 명령어가 rsp보다 아래 주소에 먼저 접근함  e.g. PUSH, CALL, INT */
-		// if (STACK_LIMIT <= rsp - 8 && rsp - 8 == addr && addr <= USER_STACK) {
-        //     vm_stack_growth(addr);
-		// 	return true;
-		// }
-		// /* Case2: 지역 변수 접근, 배열 사용 등  e.g. 일반적인 스택 사용 */
-		// else if (STACK_LIMIT <= rsp && rsp <= addr && addr <= USER_STACK){
-		// 	vm_stack_growth(addr);
-		// 	return true;
-		// }
-
+		// 4. lazy load 처리
 		struct page *page = spt_find_page(spt, addr);	
 		if (page == NULL) 
 			return false;
 
-		// 4. 존재하는 페이지지만 write 불가인 경우
-		if (write && page && !page->writable) // write 불가능한 페이지에 write 요청한 경우
+		// 5. write 불가능한 페이지에 write 요청한 경우
+		if (write && page && !page->writable)
 			return false;
 
-		// 5. 정상적인 lazy load 요청
+		// 6. lazy page 실제 가져오기
 		// stack growth 아니고, 기존에 SPT에 등록된 lazy page를 실제로 가져오는 path임
 		return vm_do_claim_page(page);
     }
-
-	return false;	// 스택 확장 조건에도 맞지 않으면 fault
+	// 7. not_present == false → 아직 wp 미처리라면 false
+	return false;
 }
 
 /* Free the page.
@@ -340,8 +329,8 @@ supplemental_page_table_init (struct supplemental_page_table *spt)
 
 /* Copy supplemental page table from src to dst */
 bool
-supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
-		struct supplemental_page_table *src UNUSED) 
+supplemental_page_table_copy (struct supplemental_page_table *dst,
+		struct supplemental_page_table *src) 
 {
 	struct hash_iterator i;
 	hash_first(&i, &src->pages);
@@ -349,39 +338,46 @@ supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
 	{
 		// src_page 정보
 		struct page *src_page = hash_entry(hash_cur(&i), struct page, hash_elem);
-		enum vm_type type = src_page->operations->type;
+		enum vm_type type = src_page->operations->type;		// 현재 페이지는 어떤 타입인지 (VM_UNINIT, VM_ANON, VM_FILE 중 하나)
 		void *upage = src_page->va;
 		bool writable = src_page->writable;
 
 		/* 1) type이 uninit이면 */
-		if (type == VM_UNINIT)
-		{ 	// uninit page 생성 & 초기화
+		if (VM_TYPE(type) == VM_UNINIT)
+		{ 	
+			enum vm_type real_type = VM_TYPE(src_page->uninit.type);	// 지금은 아직 UNINIT지만, 나중에 page fault가 터지면 어떤 타입으로 쓸 건지
 			vm_initializer *init = src_page->uninit.init;
 			void *aux = src_page->uninit.aux;
-			vm_alloc_page_with_initializer(VM_ANON, upage, writable, init, aux);
+
+			/* page fault 시 lazy load 를 위해 필요 */
+			if (!vm_alloc_page_with_initializer(real_type, upage, writable, init, aux))
+				return false;
+
 			continue;
 		}
 
 		/* 2) type이 file이면{ */
-		if (type == VM_FILE) 
-		{	// file 
+		if (VM_TYPE(type) == VM_FILE) 
+		{	
 			struct lazy_load_arg *aux = malloc(sizeof(struct lazy_load_arg));
             aux->file = src_page->file.file;
             aux->ofs = src_page->file.ofs;
             aux->read_bytes = src_page->file.read_bytes;
             aux->zero_bytes = src_page->file.zero_bytes;
-            if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, aux))
-                return false;
-            struct page *page = spt_find_page(dst, upage);
-            file_backed_initializer(page, type, NULL);
-            page->frame = src_page->frame;
-            pml4_set_page(thread_current()->pml4, page->va, src_page->frame->kva, src_page->writable);
-            continue;
 
+			/* file_backed_initializer 자동 호출되므로 init은 NULL, aux는 file 읽기 정보 위해 필요 */
+            if (!vm_alloc_page_with_initializer(VM_TYPE(type), upage, writable, NULL, aux))
+                return false;
+
+            // struct page *page = spt_find_page(dst, upage);
+            // file_backed_initializer(page, type, NULL);
+            // page->frame = src_page->frame;
+            // pml4_set_page(thread_current()->pml4, page->va, src_page->frame->kva, src_page->writable);
+            continue;
 		}
 
-		/* 3) type이 uninit이 아니면 */
-		if (!vm_alloc_page_with_initializer(type, upage, writable, NULL, NULL)) // uninit page 생성 & 초기화
+		/* 3) type이 uninit이 아니면 바로 claim 해서 쓰므로 필요 없음 */
+		if (!vm_alloc_page_with_initializer(VM_TYPE(type), upage, writable, NULL, NULL)) // uninit page 생성 & 초기화
 			// init(lazy_load_segment)는 page_fault가 발생할때 호출됨
 			// 지금 만드는 페이지는 page_fault가 일어날 때까지 기다리지 않고 바로 내용을 넣어줘야 하므로 필요 없음
 			return false;
@@ -396,6 +392,90 @@ supplemental_page_table_copy (struct supplemental_page_table *dst UNUSED,
 	}
 	return true;
 }
+
+// bool
+// supplemental_page_table_copy (struct supplemental_page_table *dst,
+//                               struct supplemental_page_table *src) 
+// {
+//     struct hash_iterator i;
+//     hash_first(&i, &src->pages);
+//     while (hash_next(&i))
+//     {
+//         struct page *src_page = hash_entry(hash_cur(&i), struct page, hash_elem);
+//         enum vm_type type = src_page->operations->type;
+
+//         // ⭐ 실제 type 결정 (VM_UNINIT이면 미래 type 사용)
+//         enum vm_type real_type = (type == VM_UNINIT) ? VM_TYPE(src_page->uninit.type) : VM_TYPE(type);
+
+//         void *upage = src_page->va;
+//         bool writable = src_page->writable;
+
+//         // 1️⃣ ANON 처리
+//         if (real_type == VM_ANON)
+//         {
+//             vm_initializer *init = NULL;
+//             void *aux = NULL;
+
+//             // UNINIT이면 기존 init, aux 복사
+//             if (type == VM_UNINIT)
+//             {
+//                 init = src_page->uninit.init;
+//                 aux = src_page->uninit.aux;
+//             }
+
+//             if (!vm_alloc_page_with_initializer(real_type, upage, writable, init, aux))
+//                 return false;
+
+//             // claim 후 내용 복사
+//             if (!vm_claim_page(upage))
+//                 return false;
+
+//             struct page *dst_page = spt_find_page(dst, upage);
+//             memcpy(dst_page->frame->kva, src_page->frame->kva, PGSIZE);
+//             continue;
+//         }
+
+//         // 2️⃣ FILE 처리
+//         else if (real_type == VM_FILE)
+//         {
+//             struct lazy_load_arg *aux = malloc(sizeof(struct lazy_load_arg));
+//             if (aux == NULL)
+//                 return false;
+
+//             // src_page에서 file 관련 정보 복사
+//             aux->file = src_page->file.file;
+//             aux->ofs = src_page->file.ofs;
+//             aux->read_bytes = src_page->file.read_bytes;
+//             aux->zero_bytes = src_page->file.zero_bytes;
+
+//             if (!vm_alloc_page_with_initializer(real_type, upage, writable, NULL, aux))
+//             {
+//                 free(aux);
+//                 return false;
+//             }
+
+//             // ⭐ FILE page는 claim 하면 안 됨 (lazy load 유지해야 함)
+//             continue;
+//         }
+
+//         // 3️⃣ 나머지 타입 처리: ex) VM_MARKER_x 가 붙은 ANON page 등
+//         else
+//         {
+//             if (!vm_alloc_page_with_initializer(real_type, upage, writable, NULL, NULL))
+// 				return false;
+
+// 			if (!vm_claim_page(upage))
+// 				return false;
+
+// 			struct page *dst_page = spt_find_page(dst, upage);
+// 			memcpy(dst_page->frame->kva, src_page->frame->kva, PGSIZE);
+
+// 			continue;
+//         }
+//     }
+//     return true;
+// }
+
 
 /* Free the resource hold by the supplemental page table */
 void


### PR DESCRIPTION
```
FAIL tests/vm/pt-grow-stk-sc
Test output failed to match any acceptable form.

Acceptable output:
  (pt-grow-stk-sc) begin
  (pt-grow-stk-sc) create "sample.txt"
  (pt-grow-stk-sc) open "sample.txt"
  (pt-grow-stk-sc) write "sample.txt"
  (pt-grow-stk-sc) 2nd open "sample.txt"
  (pt-grow-stk-sc) read "sample.txt"
  (pt-grow-stk-sc) compare written data against read data
  (pt-grow-stk-sc) end
Differences in `diff -u' format:
  (pt-grow-stk-sc) begin
  (pt-grow-stk-sc) create "sample.txt"
  (pt-grow-stk-sc) open "sample.txt"
  (pt-grow-stk-sc) write "sample.txt"
  (pt-grow-stk-sc) 2nd open "sample.txt"
  (pt-grow-stk-sc) read "sample.txt"
- (pt-grow-stk-sc) compare written data against read data
- (pt-grow-stk-sc) end
```

```
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
pass tests/vm/pt-write-code2
FAIL tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
pass tests/vm/page-parallel
pass tests/vm/page-merge-seq
pass tests/vm/page-merge-par
pass tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
FAIL tests/vm/mmap-read
FAIL tests/vm/mmap-close
FAIL tests/vm/mmap-unmap
FAIL tests/vm/mmap-overlap
FAIL tests/vm/mmap-twice
FAIL tests/vm/mmap-write
FAIL tests/vm/mmap-ro
FAIL tests/vm/mmap-exit
FAIL tests/vm/mmap-shuffle
pass tests/vm/mmap-bad-fd
FAIL tests/vm/mmap-clean
FAIL tests/vm/mmap-inherit
pass tests/vm/mmap-misalign
pass tests/vm/mmap-null
pass tests/vm/mmap-over-code
pass tests/vm/mmap-over-data
pass tests/vm/mmap-over-stk
FAIL tests/vm/mmap-remove
pass tests/vm/mmap-zero
pass tests/vm/mmap-bad-fd2
pass tests/vm/mmap-bad-fd3
pass tests/vm/mmap-zero-len
FAIL tests/vm/mmap-off
FAIL tests/vm/mmap-bad-off
pass tests/vm/mmap-kernel
FAIL tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
pass tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
21 of 141 tests failed.
```