### PR TITLE
🐛 fix(syscall.c): use check_valid_buffer() instead of check_address() in read() for proper stack growth handling (pt-grow-stk-sc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,7 +79,6 @@ core
 Thumbs.db
 
 # IDE 관련 파일
-.vscode/
 .idea/
 *.sublime-workspace
 *.sublime-project

--- a/.vscode/bashrc_with_activate
+++ b/.vscode/bashrc_with_activate
@@ -1,0 +1,3 @@
+#!/bin/bash
+source ~/.bashrc
+source ./activate

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    "configurations": [
+      
+      {
+        "type": "gdb",
+        "request": "attach",
+        "name": "Project1_threads",
+        "executable": "${workspaceFolder}/pintos-kaist/threads/build/kernel.o",
+        "target": "localhost:1234",
+        "remote": true,
+        "cwd": "${workspaceFolder}",
+        "valuesFormatting": "parseText"
+      },
+      {
+        "type": "gdb",
+        "request": "attach",
+        "name": "Project2_userprog",
+        "executable": "${workspaceFolder}/pintos-kaist/userprog/build/kernel.o",
+        "target": "localhost:1234",
+        "remote": true,
+        "cwd": "${workspaceFolder}",
+        "valuesFormatting": "parseText"
+      },
+      {
+        "type": "gdb",
+        "request": "attach",
+        "name": "Project3_vm",
+        "executable": "${workspaceFolder}/pintos-kaist/vm/build/kernel.o",
+        "target": "localhost:1234",
+        "remote": true,
+        "cwd": "${workspaceFolder}",
+        "valuesFormatting": "parseText"
+      }
+    ]
+  }

--- a/.vscode/setting.json
+++ b/.vscode/setting.json
@@ -1,0 +1,9 @@
+{
+    "terminal.integrated.profiles.linux": {
+      "bash-with-activate": {
+        "path": "bash",
+        "args": ["--rcfile", "${workspaceFolder}/.vscode/bashrc_with_activate"]
+      }
+    },
+    "terminal.integrated.defaultProfile.linux": "bash-with-activate"
+  }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{
+    "files.associations": {
+        "synch.h": "c",
+        "stdbool.h": "c",
+        "thread.h": "c",
+        "*.inc": "c",
+        "random.h": "c",
+        "process.h": "c",
+        "pte.h": "c",
+        "mmu.h": "c",
+        "vaddr.h": "c",
+        "algorithm": "c",
+        "main.h": "c",
+        "syscall.h": "c",
+        "syscall-nr.h": "c",
+        "lib.h": "c",
+        "interrupt.h": "c",
+        "filesys.h": "c",
+        "init.h": "c",
+        "string.h": "c",
+        "palloc.h": "c",
+        "memory_resource": "c",
+        "stdio.h": "c"
+    },
+    "C_Cpp.errorSquiggles": "disabled"
+}

--- a/threads/synch.c
+++ b/threads/synch.c
@@ -336,11 +336,12 @@ cond_signal (struct condition *cond, struct lock *lock UNUSED) {
 	ASSERT (!intr_context ());
 	ASSERT (lock_held_by_current_thread (lock));
 
-	if (!list_empty (&cond->waiters))
+	if (!list_empty (&cond->waiters)) {
 		/* 세마포어의 watier list내에 스레드들의 우선순위에 따라 정렬한다. */	
 	   list_sort(&cond->waiters, cmp_sem_priority, NULL);
 		sema_up (&list_entry (list_pop_front (&cond->waiters),
 					struct semaphore_elem, elem)->semaphore);
+   }
 }
 
 /* Wakes up all threads, if any, waiting on COND (protected by

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -51,17 +51,37 @@ void check_address(void *addr)
     if (!is_user_vaddr(addr) || addr == NULL)   // null이거나 커널 영역 접근 시
         exit(-1);
 
-    #ifdef VM
-        /* SPT에 존재하지 않는다면 잘못된 접근 */
-        struct thread *t = thread_current();
-        if (spt_find_page(&t->spt, addr) == NULL)
-            exit(-1);
-    #else
-        /* 페이지 테이블에서 직접 확인 (Project 2까지) */
-        if (pml4_get_page(thread_current()->pml4, addr) == NULL)
-            exit(-1);
-    #endif        
+    /* 페이지 테이블에서 직접 확인 (Project 2까지) */
+    if (pml4_get_page(thread_current()->pml4, addr) == NULL)
+        exit(-1);
+
+    return spt_find_page (&thread_current ()->spt, addr);
 }
+
+#ifdef VM
+/* Validate user buffer. If WRITABLE is true, the buffer must be writable. */
+static void
+check_valid_buffer (void *buffer, size_t size, bool writable)
+{
+    for (size_t i = 0; i < size; i += 8)
+    {
+        void *addr = (uint8_t *)buffer + i;
+        struct page *page = spt_find_page (&thread_current ()->spt, addr);
+
+        if (!is_user_vaddr(addr))
+            exit (-1);
+
+        if (writable && page && !page->writable)
+            exit (-1);
+    }
+}
+#else
+static void
+check_valid_buffer (void *buffer, size_t size UNUSED, bool writable UNUSED)
+{
+    check_address (buffer);
+}
+#endif
 
 void
 syscall_init (void) {
@@ -82,7 +102,9 @@ syscall_init (void) {
 void
 syscall_handler (struct intr_frame *f) 
 {
+#ifdef VM
     thread_current()->saved_user_rsp = f->rsp;    // 현재 스레드에 유저 스택 포인터 저장
+#endif
 
 	switch (f->R.rax) {
 	case SYS_HALT:
@@ -152,8 +174,9 @@ void exit(int status){
     thread_exit();
 }
 
-int write(int fd, const void *buffer, unsigned size) {
-	check_address(buffer);
+int write(int fd, const void *buffer, unsigned size) 
+{
+    check_valid_buffer ((void *)buffer, size, false);
 
     off_t bytes = -1;
 
@@ -224,9 +247,11 @@ tid_t fork(const char *thread_name, struct intr_frame *f) {
     return process_fork(thread_name, f);  // 실제 유저 컨텍스트를 넘긴다
 }
 
-int read(int fd, void *buffer, unsigned size) 
+int read(int fd, void *buffer, unsigned size)
 {
-	check_address(buffer);
+    // check_address(buffer);   // [pt-grow-stk-sc] pml4_get_page(thread_current()->pml4, addr) == NULL 조건에서 걸림
+    check_valid_buffer (buffer, size, true);
+
     lock_acquire(&filesys_lock);
     if (fd == 0) {  // 0(stdin) -> keyboard로 직접 입력
         int i = 0;  // 쓰레기 값 return 방지
@@ -258,58 +283,19 @@ int read(int fd, void *buffer, unsigned size)
         return -1;
     }
 
-#ifdef VM
-    struct page *page = spt_find_page(&thread_current()->spt, buffer);
-    if (page && !page->writable){
-        lock_release(&filesys_lock);
-        exit(-1);
-    }
-#endif
+// #ifdef VM   // [pt-grow-stk-sc] 이건 주석 처리하던 말던 상관 없음
+//     struct page *page = spt_find_page(&thread_current()->spt, buffer);
+//     if (page && !page->writable){
+//         lock_release(&filesys_lock);
+//         exit(-1);
+//     }
+// #endif
 
     bytes = file_read(file, buffer, size);
     lock_release(&filesys_lock);
 
     return bytes;
 }
-
-// int 
-// read(int fd, void *buffer, unsigned length) 
-// {
-//     struct thread *curr = thread_current();
-//     check_address(buffer);
-// /** #project3-Stack Growth */
-// #ifdef VM
-//     struct page *page = spt_find_page(&thread_current()->spt, buffer);
-//     if (page && !page->writable)
-//         exit(-1);
-// #endif
-//     struct file *file = process_get_file(fd);
-
-//     if (file == 0) { 
-//         int i = 0; 
-//         char c;
-//         unsigned char *buf = buffer;
-
-//         for (; i < length; i++) {
-//             c = input_getc();
-//             *buf++ = c;
-//             if (c == '\0')
-//                 break;
-//         }
-//         return i;
-//     }
-
-//     if (file == NULL || file == 1 || file == 2)  // 빈 파일, stdout, stderr를 읽으려고 할 경우
-//         return -1;
-
-//     off_t bytes = -1;
-
-//     lock_acquire(&filesys_lock);
-//     bytes = file_read(file, buffer, length);
-//     lock_release(&filesys_lock);
-
-//     return bytes;
-// }
 
 // 파일 디스크럽터를 사용하여 파일의 크기를 가져오는 함수
 int filesize(int fd) {


### PR DESCRIPTION
```
pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
pass tests/vm/pt-write-code2
pass tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
pass tests/vm/page-parallel
pass tests/vm/page-merge-seq
pass tests/vm/page-merge-par
pass tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
FAIL tests/vm/mmap-read
FAIL tests/vm/mmap-close
FAIL tests/vm/mmap-unmap
FAIL tests/vm/mmap-overlap
FAIL tests/vm/mmap-twice
FAIL tests/vm/mmap-write
FAIL tests/vm/mmap-ro
FAIL tests/vm/mmap-exit
FAIL tests/vm/mmap-shuffle
pass tests/vm/mmap-bad-fd
FAIL tests/vm/mmap-clean
FAIL tests/vm/mmap-inherit
pass tests/vm/mmap-misalign
pass tests/vm/mmap-null
pass tests/vm/mmap-over-code
pass tests/vm/mmap-over-data
pass tests/vm/mmap-over-stk
FAIL tests/vm/mmap-remove
pass tests/vm/mmap-zero
pass tests/vm/mmap-bad-fd2
pass tests/vm/mmap-bad-fd3
pass tests/vm/mmap-zero-len
FAIL tests/vm/mmap-off
FAIL tests/vm/mmap-bad-off
pass tests/vm/mmap-kernel
FAIL tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
pass tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
20 of 141 tests failed.
```